### PR TITLE
feat(auth): add password authentication, refactor member ownership and naming

### DIFF
--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -21,9 +21,14 @@ const post = <T>(path: string, body: unknown) => request<T>('POST', path, body);
 const put = <T>(path: string, body: unknown) => request<T>('PUT', path, body);
 const del = (path: string) => request<void>('DELETE', path);
 
+// --- Auth ---
+export const auth = {
+	login: (body: { email: string; password: string }) => post<User>('/auth/login', body)
+};
+
 // --- Users ---
 export const users = {
-	create: (body: { email: string; name: string }) => post<User>('/users', body),
+	create: (body: { email: string; name: string; password: string }) => post<User>('/users', body),
 	get: (userID: string) => get<User>(`/users/${userID}`)
 };
 

--- a/front/src/lib/components/login-form.svelte
+++ b/front/src/lib/components/login-form.svelte
@@ -1,71 +1,78 @@
 <script lang="ts">
-	import { Button } from "$lib/components/ui/button/index.js";
-	import * as Card from "$lib/components/ui/card/index.js";
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
 	import {
 		FieldGroup,
 		Field,
 		FieldLabel,
-		FieldDescription,
-		FieldSeparator,
-	} from "$lib/components/ui/field/index.js";
-	import { Input } from "$lib/components/ui/input/index.js";
-	import { cn } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+		FieldDescription
+	} from '$lib/components/ui/field/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { auth } from '$lib/api';
+	import { login } from '$lib/stores/auth';
 
 	let { class: className, ...restProps }: HTMLAttributes<HTMLDivElement> = $props();
 
 	const id = $props.id();
+
+	let email = $state('');
+	let password = $state('');
+	let errorMessage = $state('');
+	let loading = $state(false);
+
+	async function handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		errorMessage = '';
+		loading = true;
+		try {
+			const user = await auth.login({ email, password });
+			login(user);
+			goto('/');
+		} catch (err) {
+			errorMessage = err instanceof Error ? err.message : 'Login failed';
+		} finally {
+			loading = false;
+		}
+	}
 </script>
 
-<div class={cn("flex flex-col gap-6", className)} {...restProps}>
+<div class={cn('flex flex-col gap-6', className)} {...restProps}>
 	<Card.Root>
 		<Card.Header class="text-center">
 			<Card.Title class="text-xl">Welcome back</Card.Title>
-			<Card.Description>Login with your Apple or Google account</Card.Description>
+			<Card.Description>Sign in to your account</Card.Description>
 		</Card.Header>
 		<Card.Content>
-			<form>
+			<form onsubmit={handleSubmit}>
 				<FieldGroup>
 					<Field>
-						<Button variant="outline" type="button">
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-								<path
-									d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"
-									fill="currentColor"
-								/>
-							</svg>
-							Login with Apple
-						</Button>
-						<Button variant="outline" type="button">
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-								<path
-									d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
-									fill="currentColor"
-								/>
-							</svg>
-							Login with Google
-						</Button>
-					</Field>
-					<FieldSeparator class="*:data-[slot=field-separator-content]:bg-card">
-						Or continue with
-					</FieldSeparator>
-					<Field>
 						<FieldLabel for="email-{id}">Email</FieldLabel>
-						<Input id="email-{id}" type="email" placeholder="m@example.com" required />
+						<Input
+							id="email-{id}"
+							type="email"
+							placeholder="m@example.com"
+							required
+							bind:value={email}
+						/>
 					</Field>
 					<Field>
 						<div class="flex items-center">
 							<FieldLabel for="password-{id}">Password</FieldLabel>
-							<a href="##" class="ms-auto text-sm underline-offset-4 hover:underline">
-								Forgot your password?
-							</a>
 						</div>
-						<Input id="password-{id}" type="password" required />
+						<Input id="password-{id}" type="password" required bind:value={password} />
 					</Field>
+					{#if errorMessage}
+						<p class="text-destructive text-sm">{errorMessage}</p>
+					{/if}
 					<Field>
-						<Button type="submit">Login</Button>
+						<Button type="submit" disabled={loading}>
+							{loading ? 'Signing in…' : 'Login'}
+						</Button>
 						<FieldDescription class="text-center">
-							Don't have an account? <a href="##">Sign up</a>
+							Don't have an account? Contact your administrator.
 						</FieldDescription>
 					</Field>
 				</FieldGroup>

--- a/front/src/lib/components/nav-user.svelte
+++ b/front/src/lib/components/nav-user.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import * as Avatar from "$lib/components/ui/avatar/index.js";
 	import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
 	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
@@ -9,9 +10,15 @@
 	import CreditCardIcon from "@lucide/svelte/icons/credit-card";
 	import LogOutIcon from "@lucide/svelte/icons/log-out";
 	import SparklesIcon from "@lucide/svelte/icons/sparkles";
+	import { logout } from '$lib/stores/auth';
 
 	let { user }: { user: { name: string; email: string; avatar: string } } = $props();
 	const sidebar = useSidebar();
+
+	function handleLogout() {
+		logout();
+		goto('/login');
+	}
 </script>
 
 <Sidebar.Menu>
@@ -77,7 +84,7 @@
 					</DropdownMenu.Item>
 				</DropdownMenu.Group>
 				<DropdownMenu.Separator />
-				<DropdownMenu.Item>
+				<DropdownMenu.Item onclick={handleLogout}>
 					<LogOutIcon />
 					Log out
 				</DropdownMenu.Item>

--- a/front/src/lib/stores/auth.ts
+++ b/front/src/lib/stores/auth.ts
@@ -1,0 +1,27 @@
+import { writable } from 'svelte/store';
+import type { User } from '$lib/api';
+
+const STORAGE_KEY = 'user';
+
+function loadFromStorage(): User | null {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		return raw ? (JSON.parse(raw) as User) : null;
+	} catch {
+		return null;
+	}
+}
+
+const _store = writable<User | null>(loadFromStorage());
+
+export const currentUser = { subscribe: _store.subscribe };
+
+export function login(user: User): void {
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+	_store.set(user);
+}
+
+export function logout(): void {
+	localStorage.removeItem(STORAGE_KEY);
+	_store.set(null);
+}

--- a/front/src/routes/(app)/+layout.ts
+++ b/front/src/routes/(app)/+layout.ts
@@ -1,0 +1,8 @@
+import { browser } from '$app/environment';
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+	if (browser && !localStorage.getItem('user')) {
+		redirect(302, '/login');
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
 )
+
+require golang.org/x/crypto v0.48.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=

--- a/internal/boards/boards.go
+++ b/internal/boards/boards.go
@@ -45,14 +45,14 @@ type CreateBoardParams struct {
 	FilterQuery string
 }
 
-func (p CreateBoardParams) Validate() error {
-	if p.ProjectID == "" {
+func (params CreateBoardParams) Validate() error {
+	if params.ProjectID == "" {
 		return errors.New("project_id is required")
 	}
-	if p.Name == "" {
+	if params.Name == "" {
 		return errors.New("name is required")
 	}
-	if !validBoardTypes[p.Type] {
+	if !validBoardTypes[params.Type] {
 		return errors.New("type must be 'kanban' or 'scrum'")
 	}
 	return nil
@@ -63,24 +63,24 @@ type AddColumnParams struct {
 	Name    string
 }
 
-func (p AddColumnParams) Validate() error {
-	if p.BoardID == "" {
+func (params AddColumnParams) Validate() error {
+	if params.BoardID == "" {
 		return errors.New("board_id is required")
 	}
-	if p.Name == "" {
+	if params.Name == "" {
 		return errors.New("name is required")
 	}
 	return nil
 }
 
-func CreateBoard(ctx context.Context, db *sqlx.DB, p CreateBoardParams) (Board, error) {
+func CreateBoard(ctx context.Context, db *sqlx.DB, params CreateBoardParams) (Board, error) {
 	if db == nil {
 		return Board{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return Board{}, err
 	}
-	return createBoard(ctx, db, p)
+	return createBoard(ctx, db, params)
 }
 
 func GetBoard(ctx context.Context, db *sqlx.DB, id string) (Board, error) {
@@ -113,14 +113,14 @@ func ArchiveBoard(ctx context.Context, db *sqlx.DB, id string) error {
 	return archiveBoard(ctx, db, id)
 }
 
-func AddColumn(ctx context.Context, db *sqlx.DB, p AddColumnParams) (BoardColumn, error) {
+func AddColumn(ctx context.Context, db *sqlx.DB, params AddColumnParams) (BoardColumn, error) {
 	if db == nil {
 		return BoardColumn{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return BoardColumn{}, err
 	}
-	return addColumn(ctx, db, p)
+	return addColumn(ctx, db, params)
 }
 
 func ListColumns(ctx context.Context, db *sqlx.DB, boardID string) ([]BoardColumn, error) {

--- a/internal/boards/boards_test.go
+++ b/internal/boards/boards_test.go
@@ -8,44 +8,44 @@ import (
 func TestCreateBoardParams_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		p       CreateBoardParams
+		params  CreateBoardParams
 		wantErr bool
 	}{
 		{
 			name:    "valid kanban",
-			p:       CreateBoardParams{ProjectID: "proj-1", Name: "Main Board", Type: "kanban"},
+			params:  CreateBoardParams{ProjectID: "proj-1", Name: "Main Board", Type: "kanban"},
 			wantErr: false,
 		},
 		{
 			name:    "valid scrum",
-			p:       CreateBoardParams{ProjectID: "proj-1", Name: "Sprint Board", Type: "scrum"},
+			params:  CreateBoardParams{ProjectID: "proj-1", Name: "Sprint Board", Type: "scrum"},
 			wantErr: false,
 		},
 		{
 			name:    "missing project_id",
-			p:       CreateBoardParams{ProjectID: "", Name: "Main Board", Type: "kanban"},
+			params:  CreateBoardParams{ProjectID: "", Name: "Main Board", Type: "kanban"},
 			wantErr: true,
 		},
 		{
 			name:    "missing name",
-			p:       CreateBoardParams{ProjectID: "proj-1", Name: "", Type: "kanban"},
+			params:  CreateBoardParams{ProjectID: "proj-1", Name: "", Type: "kanban"},
 			wantErr: true,
 		},
 		{
 			name:    "invalid type",
-			p:       CreateBoardParams{ProjectID: "proj-1", Name: "Main Board", Type: "other"},
+			params:  CreateBoardParams{ProjectID: "proj-1", Name: "Main Board", Type: "other"},
 			wantErr: true,
 		},
 		{
 			name:    "empty type",
-			p:       CreateBoardParams{ProjectID: "proj-1", Name: "Main Board", Type: ""},
+			params:  CreateBoardParams{ProjectID: "proj-1", Name: "Main Board", Type: ""},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
+			err := tt.params.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -56,29 +56,29 @@ func TestCreateBoardParams_Validate(t *testing.T) {
 func TestAddColumnParams_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		p       AddColumnParams
+		params  AddColumnParams
 		wantErr bool
 	}{
 		{
 			name:    "valid",
-			p:       AddColumnParams{BoardID: "board-1", Name: "To Do"},
+			params:  AddColumnParams{BoardID: "board-1", Name: "To Do"},
 			wantErr: false,
 		},
 		{
 			name:    "missing board_id",
-			p:       AddColumnParams{BoardID: "", Name: "To Do"},
+			params:  AddColumnParams{BoardID: "", Name: "To Do"},
 			wantErr: true,
 		},
 		{
 			name:    "missing name",
-			p:       AddColumnParams{BoardID: "board-1", Name: ""},
+			params:  AddColumnParams{BoardID: "board-1", Name: ""},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
+			err := tt.params.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/boards/handler.go
+++ b/internal/boards/handler.go
@@ -42,17 +42,17 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		p := CreateBoardParams{
+		params := CreateBoardParams{
 			ProjectID:   r.PathValue("projectID"),
 			Name:        body.Name,
 			Type:        body.Type,
 			FilterQuery: body.FilterQuery,
 		}
-		if err := p.Validate(); err != nil {
+		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		b, err := CreateBoard(r.Context(), db, p)
+		b, err := CreateBoard(r.Context(), db, params)
 		if err != nil {
 			fail(w, err)
 			return
@@ -102,12 +102,12 @@ func handleAddColumn(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		p := AddColumnParams{BoardID: r.PathValue("boardID"), Name: body.Name}
-		if err := p.Validate(); err != nil {
+		params := AddColumnParams{BoardID: r.PathValue("boardID"), Name: body.Name}
+		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		col, err := AddColumn(r.Context(), db, p)
+		col, err := AddColumn(r.Context(), db, params)
 		if err != nil {
 			fail(w, err)
 			return

--- a/internal/boards/store_integration_test.go
+++ b/internal/boards/store_integration_test.go
@@ -27,16 +27,16 @@ func TestCreateBoard(t *testing.T) {
 			name: "creates kanban board",
 			arrange: func(t *testing.T, db *sqlx.DB) (CreateBoardParams, func(*testing.T)) {
 				proj := seedProject(t, db)
-				p := CreateBoardParams{ProjectID: proj, Name: "Main Board", Type: "kanban"}
-				return p, func(t *testing.T) {}
+				params := CreateBoardParams{ProjectID: proj, Name: "Main Board", Type: "kanban"}
+				return params, func(t *testing.T) {}
 			},
 		},
 		{
 			name: "creates scrum board",
 			arrange: func(t *testing.T, db *sqlx.DB) (CreateBoardParams, func(*testing.T)) {
 				proj := seedProject(t, db)
-				p := CreateBoardParams{ProjectID: proj, Name: "Sprint Board", Type: "scrum", FilterQuery: "type=story"}
-				return p, func(t *testing.T) {}
+				params := CreateBoardParams{ProjectID: proj, Name: "Sprint Board", Type: "scrum", FilterQuery: "type=story"}
+				return params, func(t *testing.T) {}
 			},
 		},
 		{
@@ -66,8 +66,8 @@ func TestCreateBoard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, check := tt.arrange(t, db)
-			got, err := CreateBoard(context.Background(), db, p)
+			params, check := tt.arrange(t, db)
+			got, err := CreateBoard(context.Background(), db, params)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("CreateBoard() error = %v, wantErr = %v", err, tt.wantErr)
 			}
@@ -75,11 +75,11 @@ func TestCreateBoard(t *testing.T) {
 				if got.ID == "" {
 					t.Fatal("expected non-empty id")
 				}
-				if got.ProjectID != p.ProjectID {
-					t.Fatalf("project_id: got %q, want %q", got.ProjectID, p.ProjectID)
+				if got.ProjectID != params.ProjectID {
+					t.Fatalf("project_id: got %q, want %q", got.ProjectID, params.ProjectID)
 				}
-				if got.Type != p.Type {
-					t.Fatalf("type: got %q, want %q", got.Type, p.Type)
+				if got.Type != params.Type {
+					t.Fatalf("type: got %q, want %q", got.Type, params.Type)
 				}
 			}
 			if check != nil {
@@ -209,8 +209,8 @@ func TestAddColumn(t *testing.T) {
 			name: "adds first column at position 0",
 			arrange: func(t *testing.T, db *sqlx.DB) (AddColumnParams, func(*testing.T)) {
 				board := seedBoard(t, db)
-				p := AddColumnParams{BoardID: board, Name: "To Do"}
-				return p, func(t *testing.T) {}
+				params := AddColumnParams{BoardID: board, Name: "To Do"}
+				return params, func(t *testing.T) {}
 			},
 		},
 		{
@@ -223,8 +223,8 @@ func TestAddColumn(t *testing.T) {
 				if _, err := AddColumn(context.Background(), db, AddColumnParams{BoardID: board, Name: "In Progress"}); err != nil {
 					t.Fatalf("add second column: %v", err)
 				}
-				p := AddColumnParams{BoardID: board, Name: "Done"}
-				return p, func(t *testing.T) {
+				params := AddColumnParams{BoardID: board, Name: "Done"}
+				return params, func(t *testing.T) {
 					cols, err := ListColumns(context.Background(), db, board)
 					if err != nil {
 						t.Fatalf("list columns: %v", err)
@@ -255,8 +255,8 @@ func TestAddColumn(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, check := tt.arrange(t, db)
-			got, err := AddColumn(context.Background(), db, p)
+			params, check := tt.arrange(t, db)
+			got, err := AddColumn(context.Background(), db, params)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("AddColumn() error = %v, wantErr = %v", err, tt.wantErr)
 			}

--- a/internal/issues/handler.go
+++ b/internal/issues/handler.go
@@ -46,7 +46,7 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		p := CreateIssueParams{
+		params := CreateIssueParams{
 			ProjectID:     r.PathValue("projectID"),
 			IssueTypeID:   body.IssueTypeID,
 			StatusID:      body.StatusID,
@@ -57,11 +57,11 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			AssigneeID:    body.AssigneeID,
 			ReporterID:    body.ReporterID,
 		}
-		if err := p.Validate(); err != nil {
+		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		issue, err := CreateIssue(r.Context(), db, p)
+		issue, err := CreateIssue(r.Context(), db, params)
 		if err != nil {
 			fail(w, err)
 			return
@@ -109,7 +109,7 @@ func handleUpdate(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		p := UpdateIssueParams{
+		params := UpdateIssueParams{
 			IssueID:     r.PathValue("issueID"),
 			ProjectID:   r.PathValue("projectID"),
 			Title:       body.Title,
@@ -117,11 +117,11 @@ func handleUpdate(db *sqlx.DB) http.HandlerFunc {
 			Priority:    body.Priority,
 			AssigneeID:  body.AssigneeID,
 		}
-		if err := p.Validate(); err != nil {
+		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		issue, err := UpdateIssue(r.Context(), db, p)
+		issue, err := UpdateIssue(r.Context(), db, params)
 		if err != nil {
 			fail(w, err)
 			return
@@ -150,17 +150,17 @@ func handleMove(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		p := MoveIssueParams{
+		params := MoveIssueParams{
 			ProjectID:      r.PathValue("projectID"),
 			IssueID:        r.PathValue("issueID"),
 			TargetStatusID: body.TargetStatusID,
 			TargetPosition: body.TargetPosition,
 		}
-		if err := p.Validate(); err != nil {
+		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		if err := MoveIssue(r.Context(), db, p); err != nil {
+		if err := MoveIssue(r.Context(), db, params); err != nil {
 			fail(w, err)
 			return
 		}

--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -49,23 +49,23 @@ type CreateIssueParams struct {
 	DueDate       *time.Time
 }
 
-func (p CreateIssueParams) Validate() error {
-	if p.ProjectID == "" {
+func (params CreateIssueParams) Validate() error {
+	if params.ProjectID == "" {
 		return errors.New("project_id is required")
 	}
-	if p.IssueTypeID == "" {
+	if params.IssueTypeID == "" {
 		return errors.New("issue_type_id is required")
 	}
-	if p.StatusID == "" {
+	if params.StatusID == "" {
 		return errors.New("status_id is required")
 	}
-	if p.Title == "" {
+	if params.Title == "" {
 		return errors.New("title is required")
 	}
-	if p.ReporterID == "" {
+	if params.ReporterID == "" {
 		return errors.New("reporter_id is required")
 	}
-	priority := p.Priority
+	priority := params.Priority
 	if priority == "" {
 		priority = "medium"
 	}
@@ -85,17 +85,17 @@ type UpdateIssueParams struct {
 	DueDate     *time.Time
 }
 
-func (p UpdateIssueParams) Validate() error {
-	if p.IssueID == "" {
+func (params UpdateIssueParams) Validate() error {
+	if params.IssueID == "" {
 		return errors.New("issue_id is required")
 	}
-	if p.ProjectID == "" {
+	if params.ProjectID == "" {
 		return errors.New("project_id is required")
 	}
-	if p.Title == "" {
+	if params.Title == "" {
 		return errors.New("title is required")
 	}
-	if !validPriorities[p.Priority] {
+	if !validPriorities[params.Priority] {
 		return ErrInvalidPriority
 	}
 	return nil
@@ -107,17 +107,17 @@ type ListIssuesParams struct {
 	AssigneeID string
 }
 
-func CreateIssue(ctx context.Context, db *sqlx.DB, p CreateIssueParams) (Issue, error) {
+func CreateIssue(ctx context.Context, db *sqlx.DB, params CreateIssueParams) (Issue, error) {
 	if db == nil {
 		return Issue{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return Issue{}, err
 	}
-	if p.Priority == "" {
-		p.Priority = "medium"
+	if params.Priority == "" {
+		params.Priority = "medium"
 	}
-	return createIssue(ctx, db, p)
+	return createIssue(ctx, db, params)
 }
 
 func GetIssue(ctx context.Context, db *sqlx.DB, projectID, issueID string) (Issue, error) {
@@ -133,24 +133,24 @@ func GetIssue(ctx context.Context, db *sqlx.DB, projectID, issueID string) (Issu
 	return getIssue(ctx, db, projectID, issueID)
 }
 
-func ListIssues(ctx context.Context, db *sqlx.DB, p ListIssuesParams) ([]Issue, error) {
+func ListIssues(ctx context.Context, db *sqlx.DB, params ListIssuesParams) ([]Issue, error) {
 	if db == nil {
 		return nil, errors.New("db is required")
 	}
-	if p.ProjectID == "" {
+	if params.ProjectID == "" {
 		return nil, errors.New("project_id is required")
 	}
-	return listIssues(ctx, db, p)
+	return listIssues(ctx, db, params)
 }
 
-func UpdateIssue(ctx context.Context, db *sqlx.DB, p UpdateIssueParams) (Issue, error) {
+func UpdateIssue(ctx context.Context, db *sqlx.DB, params UpdateIssueParams) (Issue, error) {
 	if db == nil {
 		return Issue{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return Issue{}, err
 	}
-	return updateIssue(ctx, db, p)
+	return updateIssue(ctx, db, params)
 }
 
 func ArchiveIssue(ctx context.Context, db *sqlx.DB, projectID, issueID string) error {
@@ -173,22 +173,22 @@ type MoveIssueParams struct {
 	TargetPosition int
 }
 
-func (p MoveIssueParams) Validate() error {
-	if p.ProjectID == "" || p.IssueID == "" {
+func (params MoveIssueParams) Validate() error {
+	if params.ProjectID == "" || params.IssueID == "" {
 		return errors.New("project_id and issue_id are required")
 	}
-	if p.TargetPosition < 0 {
+	if params.TargetPosition < 0 {
 		return errors.New("target_position must be >= 0")
 	}
 	return nil
 }
 
-func MoveIssue(ctx context.Context, db *sqlx.DB, p MoveIssueParams) error {
+func MoveIssue(ctx context.Context, db *sqlx.DB, params MoveIssueParams) error {
 	if db == nil {
 		return errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return err
 	}
-	return moveIssue(ctx, db, p)
+	return moveIssue(ctx, db, params)
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -9,34 +9,34 @@ import (
 func TestMoveIssueParams_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		p       MoveIssueParams
+		params  MoveIssueParams
 		wantErr bool
 	}{
 		{
 			name:    "valid params",
-			p:       MoveIssueParams{ProjectID: "proj-1", IssueID: "issue-1", TargetPosition: 0},
+			params:  MoveIssueParams{ProjectID: "proj-1", IssueID: "issue-1", TargetPosition: 0},
 			wantErr: false,
 		},
 		{
 			name:    "missing project_id",
-			p:       MoveIssueParams{ProjectID: "", IssueID: "issue-1", TargetPosition: 0},
+			params:  MoveIssueParams{ProjectID: "", IssueID: "issue-1", TargetPosition: 0},
 			wantErr: true,
 		},
 		{
 			name:    "missing issue_id",
-			p:       MoveIssueParams{ProjectID: "proj-1", IssueID: "", TargetPosition: 0},
+			params:  MoveIssueParams{ProjectID: "proj-1", IssueID: "", TargetPosition: 0},
 			wantErr: true,
 		},
 		{
 			name:    "negative target_position",
-			p:       MoveIssueParams{ProjectID: "proj-1", IssueID: "issue-1", TargetPosition: -1},
+			params:  MoveIssueParams{ProjectID: "proj-1", IssueID: "issue-1", TargetPosition: -1},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
+			err := tt.params.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -68,23 +68,23 @@ func TestCreateIssueParams_Validate(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		p       CreateIssueParams
+		params  CreateIssueParams
 		wantErr bool
 	}{
-		{name: "valid", p: valid, wantErr: false},
-		{name: "priority defaults to medium", p: func() CreateIssueParams { c := valid; c.Priority = ""; return c }(), wantErr: false},
-		{name: "valid with due date", p: func() CreateIssueParams { c := valid; c.DueDate = &due; return c }(), wantErr: false},
-		{name: "missing project_id", p: func() CreateIssueParams { c := valid; c.ProjectID = ""; return c }(), wantErr: true},
-		{name: "missing issue_type_id", p: func() CreateIssueParams { c := valid; c.IssueTypeID = ""; return c }(), wantErr: true},
-		{name: "missing status_id", p: func() CreateIssueParams { c := valid; c.StatusID = ""; return c }(), wantErr: true},
-		{name: "missing title", p: func() CreateIssueParams { c := valid; c.Title = ""; return c }(), wantErr: true},
-		{name: "missing reporter_id", p: func() CreateIssueParams { c := valid; c.ReporterID = ""; return c }(), wantErr: true},
-		{name: "invalid priority", p: func() CreateIssueParams { c := valid; c.Priority = "urgent"; return c }(), wantErr: true},
+		{name: "valid", params: valid, wantErr: false},
+		{name: "priority defaults to medium", params: func() CreateIssueParams { c := valid; c.Priority = ""; return c }(), wantErr: false},
+		{name: "valid with due date", params: func() CreateIssueParams { c := valid; c.DueDate = &due; return c }(), wantErr: false},
+		{name: "missing project_id", params: func() CreateIssueParams { c := valid; c.ProjectID = ""; return c }(), wantErr: true},
+		{name: "missing issue_type_id", params: func() CreateIssueParams { c := valid; c.IssueTypeID = ""; return c }(), wantErr: true},
+		{name: "missing status_id", params: func() CreateIssueParams { c := valid; c.StatusID = ""; return c }(), wantErr: true},
+		{name: "missing title", params: func() CreateIssueParams { c := valid; c.Title = ""; return c }(), wantErr: true},
+		{name: "missing reporter_id", params: func() CreateIssueParams { c := valid; c.ReporterID = ""; return c }(), wantErr: true},
+		{name: "invalid priority", params: func() CreateIssueParams { c := valid; c.Priority = "urgent"; return c }(), wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
+			err := tt.params.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -102,20 +102,20 @@ func TestUpdateIssueParams_Validate(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		p       UpdateIssueParams
+		params  UpdateIssueParams
 		wantErr bool
 	}{
-		{name: "valid", p: valid, wantErr: false},
-		{name: "missing issue_id", p: func() UpdateIssueParams { c := valid; c.IssueID = ""; return c }(), wantErr: true},
-		{name: "missing project_id", p: func() UpdateIssueParams { c := valid; c.ProjectID = ""; return c }(), wantErr: true},
-		{name: "missing title", p: func() UpdateIssueParams { c := valid; c.Title = ""; return c }(), wantErr: true},
-		{name: "invalid priority", p: func() UpdateIssueParams { c := valid; c.Priority = "asap"; return c }(), wantErr: true},
-		{name: "empty priority invalid", p: func() UpdateIssueParams { c := valid; c.Priority = ""; return c }(), wantErr: true},
+		{name: "valid", params: valid, wantErr: false},
+		{name: "missing issue_id", params: func() UpdateIssueParams { c := valid; c.IssueID = ""; return c }(), wantErr: true},
+		{name: "missing project_id", params: func() UpdateIssueParams { c := valid; c.ProjectID = ""; return c }(), wantErr: true},
+		{name: "missing title", params: func() UpdateIssueParams { c := valid; c.Title = ""; return c }(), wantErr: true},
+		{name: "invalid priority", params: func() UpdateIssueParams { c := valid; c.Priority = "asap"; return c }(), wantErr: true},
+		{name: "empty priority invalid", params: func() UpdateIssueParams { c := valid; c.Priority = ""; return c }(), wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
+			err := tt.params.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/issues/store_integration_test.go
+++ b/internal/issues/store_integration_test.go
@@ -31,8 +31,8 @@ func TestMoveIssue(t *testing.T) {
 				a := insertIssue(t, db, seed, issueSeed{number: 1, title: "A", statusID: seed.statusTodoID, statusPosition: 0})
 				b := insertIssue(t, db, seed, issueSeed{number: 2, title: "B", statusID: seed.statusTodoID, statusPosition: 1})
 				c := insertIssue(t, db, seed, issueSeed{number: 3, title: "C", statusID: seed.statusTodoID, statusPosition: 2})
-				p := MoveIssueParams{ProjectID: seed.projectID, IssueID: c, TargetStatusID: seed.statusTodoID, TargetPosition: 0}
-				return p, func(t *testing.T) {
+				params := MoveIssueParams{ProjectID: seed.projectID, IssueID: c, TargetStatusID: seed.statusTodoID, TargetPosition: 0}
+				return params, func(t *testing.T) {
 					assertOrder(t,
 						fetchStatusOrder(t, db, seed.projectID, seed.statusTodoID),
 						[]orderedIssue{{ID: c, Pos: 0}, {ID: a, Pos: 1}, {ID: b, Pos: 2}},
@@ -47,8 +47,8 @@ func TestMoveIssue(t *testing.T) {
 				b := insertIssue(t, db, seed, issueSeed{number: 2, title: "B", statusID: seed.statusTodoID, statusPosition: 1})
 				d := insertIssue(t, db, seed, issueSeed{number: 3, title: "D", statusID: seed.statusDoingID, statusPosition: 0})
 				e := insertIssue(t, db, seed, issueSeed{number: 4, title: "E", statusID: seed.statusDoingID, statusPosition: 1})
-				p := MoveIssueParams{ProjectID: seed.projectID, IssueID: b, TargetStatusID: seed.statusDoingID, TargetPosition: 1}
-				return p, func(t *testing.T) {
+				params := MoveIssueParams{ProjectID: seed.projectID, IssueID: b, TargetStatusID: seed.statusDoingID, TargetPosition: 1}
+				return params, func(t *testing.T) {
 					assertOrder(t,
 						fetchStatusOrder(t, db, seed.projectID, seed.statusTodoID),
 						[]orderedIssue{{ID: a, Pos: 0}},
@@ -65,8 +65,8 @@ func TestMoveIssue(t *testing.T) {
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (MoveIssueParams, func(*testing.T)) {
 				a := insertIssue(t, db, seed, issueSeed{number: 1, title: "A", statusID: seed.statusTodoID, statusPosition: 0})
 				b := insertIssue(t, db, seed, issueSeed{number: 2, title: "B", statusID: seed.statusTodoID, statusPosition: 1})
-				p := MoveIssueParams{ProjectID: seed.projectID, IssueID: a, TargetStatusID: seed.statusTodoID, TargetPosition: 0}
-				return p, func(t *testing.T) {
+				params := MoveIssueParams{ProjectID: seed.projectID, IssueID: a, TargetStatusID: seed.statusTodoID, TargetPosition: 0}
+				return params, func(t *testing.T) {
 					assertOrder(t,
 						fetchStatusOrder(t, db, seed.projectID, seed.statusTodoID),
 						[]orderedIssue{{ID: a, Pos: 0}, {ID: b, Pos: 1}},
@@ -78,13 +78,13 @@ func TestMoveIssue(t *testing.T) {
 			name:    "issue not found",
 			wantErr: ErrIssueNotFound,
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (MoveIssueParams, func(*testing.T)) {
-				p := MoveIssueParams{
+				params := MoveIssueParams{
 					ProjectID:      seed.projectID,
 					IssueID:        "00000000-0000-0000-0000-000000000000",
 					TargetStatusID: seed.statusTodoID,
 					TargetPosition: 0,
 				}
-				return p, nil
+				return params, nil
 			},
 		},
 		{
@@ -93,8 +93,8 @@ func TestMoveIssue(t *testing.T) {
 				a := insertIssue(t, db, seed, issueSeed{number: 1, title: "A", statusID: seed.statusTodoID, statusPosition: 0})
 				b := insertIssue(t, db, seed, issueSeed{number: 2, title: "B", statusID: seed.statusTodoID, statusPosition: 1})
 				c := insertIssue(t, db, seed, issueSeed{number: 3, title: "C", statusID: seed.statusTodoID, statusPosition: 2})
-				p := MoveIssueParams{ProjectID: seed.projectID, IssueID: a, TargetStatusID: seed.statusTodoID, TargetPosition: 999}
-				return p, func(t *testing.T) {
+				params := MoveIssueParams{ProjectID: seed.projectID, IssueID: a, TargetStatusID: seed.statusTodoID, TargetPosition: 999}
+				return params, func(t *testing.T) {
 					assertOrder(t,
 						fetchStatusOrder(t, db, seed.projectID, seed.statusTodoID),
 						[]orderedIssue{{ID: b, Pos: 0}, {ID: c, Pos: 1}, {ID: a, Pos: 2}},
@@ -108,8 +108,8 @@ func TestMoveIssue(t *testing.T) {
 				a := insertIssue(t, db, seed, issueSeed{number: 1, title: "A", statusID: seed.statusTodoID, statusPosition: 0})
 				d := insertIssue(t, db, seed, issueSeed{number: 2, title: "D", statusID: seed.statusDoingID, statusPosition: 0})
 				e := insertIssue(t, db, seed, issueSeed{number: 3, title: "E", statusID: seed.statusDoingID, statusPosition: 1})
-				p := MoveIssueParams{ProjectID: seed.projectID, IssueID: a, TargetStatusID: seed.statusDoingID, TargetPosition: 0}
-				return p, func(t *testing.T) {
+				params := MoveIssueParams{ProjectID: seed.projectID, IssueID: a, TargetStatusID: seed.statusDoingID, TargetPosition: 0}
+				return params, func(t *testing.T) {
 					assertOrder(t,
 						fetchStatusOrder(t, db, seed.projectID, seed.statusDoingID),
 						[]orderedIssue{{ID: a, Pos: 0}, {ID: d, Pos: 1}, {ID: e, Pos: 2}},
@@ -122,8 +122,8 @@ func TestMoveIssue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			seed := seedProject(t, db)
-			p, check := tt.arrange(t, db, seed)
-			err := MoveIssue(context.Background(), db, p)
+			params, check := tt.arrange(t, db, seed)
+			err := MoveIssue(context.Background(), db, params)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("MoveIssue() error = %v, wantErr = %v", err, tt.wantErr)
 			}
@@ -454,28 +454,28 @@ func TestCreateIssue(t *testing.T) {
 		{
 			name: "creates issue with auto number and position",
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (CreateIssueParams, func(*testing.T)) {
-				p := CreateIssueParams{
+				params := CreateIssueParams{
 					ProjectID: seed.projectID, IssueTypeID: seed.issueTypeID,
 					StatusID: seed.statusTodoID, Title: "First issue",
 					ReporterID: seed.reporterID, Priority: "medium",
 				}
-				return p, func(t *testing.T) {}
+				return params, func(t *testing.T) {}
 			},
 		},
 		{
 			name: "numbers increment per project",
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (CreateIssueParams, func(*testing.T)) {
-				p := CreateIssueParams{
+				params := CreateIssueParams{
 					ProjectID: seed.projectID, IssueTypeID: seed.issueTypeID,
 					StatusID: seed.statusTodoID, Title: "Issue",
 					ReporterID: seed.reporterID, Priority: "medium",
 				}
-				first, err := CreateIssue(context.Background(), db, p)
+				first, err := CreateIssue(context.Background(), db, params)
 				if err != nil {
 					t.Fatalf("create first: %v", err)
 				}
-				return p, func(t *testing.T) {
-					second, err := CreateIssue(context.Background(), db, p)
+				return params, func(t *testing.T) {
+					second, err := CreateIssue(context.Background(), db, params)
 					if err != nil {
 						t.Fatalf("create second: %v", err)
 					}
@@ -491,26 +491,26 @@ func TestCreateIssue(t *testing.T) {
 		{
 			name: "empty priority defaults to medium",
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (CreateIssueParams, func(*testing.T)) {
-				p := CreateIssueParams{
+				params := CreateIssueParams{
 					ProjectID: seed.projectID, IssueTypeID: seed.issueTypeID,
 					StatusID: seed.statusTodoID, Title: "Issue",
 					ReporterID: seed.reporterID,
 				}
-				return p, func(t *testing.T) {}
+				return params, func(t *testing.T) {}
 			},
 		},
 		{
 			name: "creates issue with optional fields",
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (CreateIssueParams, func(*testing.T)) {
 				due := time.Now().Add(48 * time.Hour)
-				p := CreateIssueParams{
+				params := CreateIssueParams{
 					ProjectID: seed.projectID, IssueTypeID: seed.issueTypeID,
 					StatusID: seed.statusTodoID, Title: "Issue with extras",
 					Description: "details", ReporterID: seed.reporterID,
 					AssigneeID: seed.reporterID, Priority: "high",
 					DueDate: &due,
 				}
-				return p, func(t *testing.T) {}
+				return params, func(t *testing.T) {}
 			},
 		},
 	}
@@ -518,8 +518,8 @@ func TestCreateIssue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			seed := seedProject(t, db)
-			p, check := tt.arrange(t, db, seed)
-			got, err := CreateIssue(context.Background(), db, p)
+			params, check := tt.arrange(t, db, seed)
+			got, err := CreateIssue(context.Background(), db, params)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("CreateIssue() error = %v, wantErr = %v", err, tt.wantErr)
 			}
@@ -646,8 +646,8 @@ func TestListIssues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			seed := seedProject(t, db)
-			p, check := tt.arrange(t, db, seed)
-			got, err := ListIssues(context.Background(), db, p)
+			params, check := tt.arrange(t, db, seed)
+			got, err := ListIssues(context.Background(), db, params)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("ListIssues() error = %v, wantErr = %v", err, tt.wantErr)
 			}
@@ -671,27 +671,27 @@ func TestUpdateIssue(t *testing.T) {
 			name: "updates title and priority",
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (UpdateIssueParams, func(*testing.T)) {
 				id := insertIssue(t, db, seed, issueSeed{number: 1, title: "Old", statusID: seed.statusTodoID, statusPosition: 0})
-				p := UpdateIssueParams{IssueID: id, ProjectID: seed.projectID, Title: "New", Priority: "high"}
-				return p, func(t *testing.T) {}
+				params := UpdateIssueParams{IssueID: id, ProjectID: seed.projectID, Title: "New", Priority: "high"}
+				return params, func(t *testing.T) {}
 			},
 		},
 		{
 			name: "clears assignee when nil",
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (UpdateIssueParams, func(*testing.T)) {
 				id := insertIssue(t, db, seed, issueSeed{number: 1, title: "A", statusID: seed.statusTodoID, statusPosition: 0})
-				p := UpdateIssueParams{IssueID: id, ProjectID: seed.projectID, Title: "A", Priority: "medium", AssigneeID: nil}
-				return p, func(t *testing.T) {}
+				params := UpdateIssueParams{IssueID: id, ProjectID: seed.projectID, Title: "A", Priority: "medium", AssigneeID: nil}
+				return params, func(t *testing.T) {}
 			},
 		},
 		{
 			name:    "not found",
 			wantErr: ErrIssueNotFound,
 			arrange: func(t *testing.T, db *sqlx.DB, seed projectSeed) (UpdateIssueParams, func(*testing.T)) {
-				p := UpdateIssueParams{
+				params := UpdateIssueParams{
 					IssueID:   "00000000-0000-0000-0000-000000000000",
 					ProjectID: seed.projectID, Title: "X", Priority: "low",
 				}
-				return p, nil
+				return params, nil
 			},
 		},
 		{
@@ -710,17 +710,17 @@ func TestUpdateIssue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			seed := seedProject(t, db)
-			p, check := tt.arrange(t, db, seed)
-			got, err := UpdateIssue(context.Background(), db, p)
+			params, check := tt.arrange(t, db, seed)
+			got, err := UpdateIssue(context.Background(), db, params)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("UpdateIssue() error = %v, wantErr = %v", err, tt.wantErr)
 			}
 			if err == nil {
-				if got.Title != p.Title {
-					t.Fatalf("title: got %q, want %q", got.Title, p.Title)
+				if got.Title != params.Title {
+					t.Fatalf("title: got %q, want %q", got.Title, params.Title)
 				}
-				if got.Priority != p.Priority {
-					t.Fatalf("priority: got %q, want %q", got.Priority, p.Priority)
+				if got.Priority != params.Priority {
+					t.Fatalf("priority: got %q, want %q", got.Priority, params.Priority)
 				}
 			}
 			if check != nil {

--- a/internal/issuetypes/handler.go
+++ b/internal/issuetypes/handler.go
@@ -38,17 +38,17 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		p := CreateIssueTypeParams{
+		params := CreateIssueTypeParams{
 			ProjectID: r.PathValue("projectID"),
 			Name:      body.Name,
 			Icon:      body.Icon,
 			Level:     body.Level,
 		}
-		if err := p.Validate(); err != nil {
+		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		it, err := CreateIssueType(r.Context(), db, p)
+		it, err := CreateIssueType(r.Context(), db, params)
 		if err != nil {
 			fail(w, err)
 			return

--- a/internal/issuetypes/issuetypes.go
+++ b/internal/issuetypes/issuetypes.go
@@ -31,27 +31,27 @@ type CreateIssueTypeParams struct {
 	Level     int
 }
 
-func (p CreateIssueTypeParams) Validate() error {
-	if p.ProjectID == "" {
+func (params CreateIssueTypeParams) Validate() error {
+	if params.ProjectID == "" {
 		return errors.New("project_id is required")
 	}
-	if p.Name == "" {
+	if params.Name == "" {
 		return errors.New("name is required")
 	}
-	if p.Level < 0 {
+	if params.Level < 0 {
 		return errors.New("level must be >= 0")
 	}
 	return nil
 }
 
-func CreateIssueType(ctx context.Context, db *sqlx.DB, p CreateIssueTypeParams) (IssueType, error) {
+func CreateIssueType(ctx context.Context, db *sqlx.DB, params CreateIssueTypeParams) (IssueType, error) {
 	if db == nil {
 		return IssueType{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return IssueType{}, err
 	}
-	return createIssueType(ctx, db, p)
+	return createIssueType(ctx, db, params)
 }
 
 func ListIssueTypes(ctx context.Context, db *sqlx.DB, projectID string) ([]IssueType, error) {

--- a/internal/issuetypes/store.go
+++ b/internal/issuetypes/store.go
@@ -11,26 +11,26 @@ import (
 
 const issueTypeCols = `id, project_id, name, icon, level, created_at, updated_at, archived_at`
 
-func createIssueType(ctx context.Context, db *sqlx.DB, p CreateIssueTypeParams) (IssueType, error) {
-	var out IssueType
+func createIssueType(ctx context.Context, db *sqlx.DB, params CreateIssueTypeParams) (IssueType, error) {
+	var issueType IssueType
 	err := db.QueryRowxContext(ctx,
 		`INSERT INTO issue_types (project_id, name, icon, level)
 		 VALUES ($1, $2, $3, $4)
 		 RETURNING `+issueTypeCols,
-		p.ProjectID, p.Name, p.Icon, p.Level,
-	).StructScan(&out)
+		params.ProjectID, params.Name, params.Icon, params.Level,
+	).StructScan(&issueType)
 	if err != nil {
 		if isUniqueViolation(err) {
 			return IssueType{}, ErrDuplicateIssueType
 		}
 		return IssueType{}, fmt.Errorf("create issue type: %w", err)
 	}
-	return out, nil
+	return issueType, nil
 }
 
 func listIssueTypes(ctx context.Context, db *sqlx.DB, projectID string) ([]IssueType, error) {
-	var out []IssueType
-	if err := db.SelectContext(ctx, &out,
+	var issueTypes []IssueType
+	if err := db.SelectContext(ctx, &issueTypes,
 		`SELECT `+issueTypeCols+`
 		 FROM issue_types
 		 WHERE project_id = $1
@@ -40,7 +40,7 @@ func listIssueTypes(ctx context.Context, db *sqlx.DB, projectID string) ([]Issue
 	); err != nil {
 		return nil, fmt.Errorf("list issue types: %w", err)
 	}
-	return out, nil
+	return issueTypes, nil
 }
 
 func archiveIssueType(ctx context.Context, db *sqlx.DB, projectID, issueTypeID string) error {

--- a/internal/projects/projects_test.go
+++ b/internal/projects/projects_test.go
@@ -8,64 +8,64 @@ import (
 func TestCreateProjectParams_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		p       CreateProjectParams
+		params  CreateProjectParams
 		wantErr bool
 	}{
 		{
 			name:    "valid",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "ENG"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "ENG"},
 			wantErr: false,
 		},
 		{
 			name:    "key exactly 2 chars",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "AB"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "AB"},
 			wantErr: false,
 		},
 		{
 			name:    "key exactly 10 chars",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "ABCDEFGHIJ"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "ABCDEFGHIJ"},
 			wantErr: false,
 		},
 		{
 			name:    "missing workspace_id",
-			p:       CreateProjectParams{WorkspaceID: "", Name: "Engineering", Key: "ENG"},
+			params:  CreateProjectParams{WorkspaceID: "", Name: "Engineering", Key: "ENG"},
 			wantErr: true,
 		},
 		{
 			name:    "missing name",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "", Key: "ENG"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "", Key: "ENG"},
 			wantErr: true,
 		},
 		{
 			name:    "key too short",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "E"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "E"},
 			wantErr: true,
 		},
 		{
 			name:    "key too long",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "ABCDEFGHIJK"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "ABCDEFGHIJK"},
 			wantErr: true,
 		},
 		{
 			name:    "key lowercase",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "eng"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "eng"},
 			wantErr: true,
 		},
 		{
 			name:    "key with digits",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "ENG1"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "ENG1"},
 			wantErr: true,
 		},
 		{
 			name:    "key with spaces",
-			p:       CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "EN G"},
+			params:  CreateProjectParams{WorkspaceID: "ws-1", Name: "Engineering", Key: "EN G"},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
+			err := tt.params.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/projects/store.go
+++ b/internal/projects/store.go
@@ -11,33 +11,34 @@ import (
 )
 
 const selectCols = `id, workspace_id, name, key, description, created_at, updated_at, archived_at`
+const memberCols = `project_id, user_id, role, created_at, updated_at, archived_at`
 
-func createProject(ctx context.Context, db *sqlx.DB, p CreateProjectParams) (Project, error) {
-	var out Project
+func createProject(ctx context.Context, db *sqlx.DB, params CreateProjectParams) (Project, error) {
+	var project Project
 	err := db.QueryRowxContext(
 		ctx,
 		`INSERT INTO projects (workspace_id, name, key, description)
 		 VALUES ($1, $2, $3, $4)
 		 RETURNING `+selectCols,
-		p.WorkspaceID,
-		p.Name,
-		p.Key,
-		p.Description,
-	).StructScan(&out)
+		params.WorkspaceID,
+		params.Name,
+		params.Key,
+		params.Description,
+	).StructScan(&project)
 	if err != nil {
 		if isUniqueViolation(err) {
 			return Project{}, ErrDuplicateProjectKey
 		}
 		return Project{}, fmt.Errorf("insert project: %w", err)
 	}
-	return out, nil
+	return project, nil
 }
 
 func getProject(ctx context.Context, db *sqlx.DB, id string) (Project, error) {
-	var out Project
+	var project Project
 	err := db.GetContext(
 		ctx,
-		&out,
+		&project,
 		`SELECT `+selectCols+`
 		 FROM projects
 		 WHERE id = $1`,
@@ -49,14 +50,14 @@ func getProject(ctx context.Context, db *sqlx.DB, id string) (Project, error) {
 		}
 		return Project{}, fmt.Errorf("get project: %w", err)
 	}
-	return out, nil
+	return project, nil
 }
 
 func listProjects(ctx context.Context, db *sqlx.DB, workspaceID string) ([]Project, error) {
-	var out []Project
+	var projects []Project
 	err := db.SelectContext(
 		ctx,
-		&out,
+		&projects,
 		`SELECT `+selectCols+`
 		 FROM projects
 		 WHERE workspace_id = $1
@@ -67,7 +68,7 @@ func listProjects(ctx context.Context, db *sqlx.DB, workspaceID string) ([]Proje
 	if err != nil {
 		return nil, fmt.Errorf("list projects: %w", err)
 	}
-	return out, nil
+	return projects, nil
 }
 
 func archiveProject(ctx context.Context, db *sqlx.DB, id string) error {
@@ -90,6 +91,75 @@ func archiveProject(ctx context.Context, db *sqlx.DB, id string) error {
 		return ErrProjectNotFound
 	}
 	return nil
+}
+
+func addMember(ctx context.Context, db *sqlx.DB, params AddMemberParams) (ProjectMember, error) {
+	var member ProjectMember
+	err := db.QueryRowxContext(ctx,
+		`INSERT INTO project_members (project_id, user_id, role)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (project_id, user_id)
+		 DO UPDATE SET role = excluded.role, archived_at = NULL
+		 RETURNING `+memberCols,
+		params.ProjectID, params.UserID, params.Role,
+	).StructScan(&member)
+	if err != nil {
+		return ProjectMember{}, fmt.Errorf("add project member: %w", err)
+	}
+	return member, nil
+}
+
+func removeMember(ctx context.Context, db *sqlx.DB, projectID, userID string) error {
+	res, err := db.ExecContext(ctx,
+		`UPDATE project_members
+		 SET archived_at = NOW()
+		 WHERE project_id = $1 AND user_id = $2 AND archived_at IS NULL`,
+		projectID, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("remove project member: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("remove project member rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrMemberNotFound
+	}
+	return nil
+}
+
+func listMembers(ctx context.Context, db *sqlx.DB, projectID string) ([]ProjectMember, error) {
+	var members []ProjectMember
+	err := db.SelectContext(ctx, &members,
+		`SELECT `+memberCols+`
+		 FROM project_members
+		 WHERE project_id = $1 AND archived_at IS NULL
+		 ORDER BY created_at ASC`,
+		projectID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list project members: %w", err)
+	}
+	return members, nil
+}
+
+func updateMemberRole(ctx context.Context, db *sqlx.DB, params UpdateMemberRoleParams) (ProjectMember, error) {
+	var member ProjectMember
+	err := db.QueryRowxContext(ctx,
+		`UPDATE project_members
+		 SET role = $1
+		 WHERE project_id = $2 AND user_id = $3 AND archived_at IS NULL
+		 RETURNING `+memberCols,
+		params.Role, params.ProjectID, params.UserID,
+	).StructScan(&member)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProjectMember{}, ErrMemberNotFound
+		}
+		return ProjectMember{}, fmt.Errorf("update project member role: %w", err)
+	}
+	return member, nil
 }
 
 func isUniqueViolation(err error) bool {

--- a/internal/statuses/handler.go
+++ b/internal/statuses/handler.go
@@ -38,16 +38,16 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		p := CreateStatusParams{
+		params := CreateStatusParams{
 			ProjectID: r.PathValue("projectID"),
 			Name:      body.Name,
 			Category:  body.Category,
 		}
-		if err := p.Validate(); err != nil {
+		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		s, err := CreateStatus(r.Context(), db, p)
+		s, err := CreateStatus(r.Context(), db, params)
 		if err != nil {
 			fail(w, err)
 			return
@@ -77,17 +77,17 @@ func handleUpdate(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		p := UpdateStatusParams{
+		params := UpdateStatusParams{
 			StatusID:  r.PathValue("statusID"),
 			ProjectID: r.PathValue("projectID"),
 			Name:      body.Name,
 			Category:  body.Category,
 		}
-		if err := p.Validate(); err != nil {
+		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		s, err := UpdateStatus(r.Context(), db, p)
+		s, err := UpdateStatus(r.Context(), db, params)
 		if err != nil {
 			fail(w, err)
 			return

--- a/internal/statuses/statuses.go
+++ b/internal/statuses/statuses.go
@@ -32,14 +32,14 @@ type CreateStatusParams struct {
 	Category  string
 }
 
-func (p CreateStatusParams) Validate() error {
-	if p.ProjectID == "" {
+func (params CreateStatusParams) Validate() error {
+	if params.ProjectID == "" {
 		return errors.New("project_id is required")
 	}
-	if p.Name == "" {
+	if params.Name == "" {
 		return errors.New("name is required")
 	}
-	if !validCategories[p.Category] {
+	if !validCategories[params.Category] {
 		return errors.New("category must be 'todo', 'doing' or 'done'")
 	}
 	return nil
@@ -52,30 +52,30 @@ type UpdateStatusParams struct {
 	Category  string
 }
 
-func (p UpdateStatusParams) Validate() error {
-	if p.StatusID == "" {
+func (params UpdateStatusParams) Validate() error {
+	if params.StatusID == "" {
 		return errors.New("status_id is required")
 	}
-	if p.ProjectID == "" {
+	if params.ProjectID == "" {
 		return errors.New("project_id is required")
 	}
-	if p.Name == "" {
+	if params.Name == "" {
 		return errors.New("name is required")
 	}
-	if !validCategories[p.Category] {
+	if !validCategories[params.Category] {
 		return errors.New("category must be 'todo', 'doing' or 'done'")
 	}
 	return nil
 }
 
-func CreateStatus(ctx context.Context, db *sqlx.DB, p CreateStatusParams) (Status, error) {
+func CreateStatus(ctx context.Context, db *sqlx.DB, params CreateStatusParams) (Status, error) {
 	if db == nil {
 		return Status{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return Status{}, err
 	}
-	return createStatus(ctx, db, p)
+	return createStatus(ctx, db, params)
 }
 
 func ListStatuses(ctx context.Context, db *sqlx.DB, projectID string) ([]Status, error) {
@@ -88,14 +88,14 @@ func ListStatuses(ctx context.Context, db *sqlx.DB, projectID string) ([]Status,
 	return listStatuses(ctx, db, projectID)
 }
 
-func UpdateStatus(ctx context.Context, db *sqlx.DB, p UpdateStatusParams) (Status, error) {
+func UpdateStatus(ctx context.Context, db *sqlx.DB, params UpdateStatusParams) (Status, error) {
 	if db == nil {
 		return Status{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return Status{}, err
 	}
-	return updateStatus(ctx, db, p)
+	return updateStatus(ctx, db, params)
 }
 
 func ArchiveStatus(ctx context.Context, db *sqlx.DB, projectID, statusID string) error {

--- a/internal/users/password.go
+++ b/internal/users/password.go
@@ -1,0 +1,55 @@
+package users
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	argon2Memory      uint32 = 64 * 1024
+	argon2Iterations  uint32 = 3
+	argon2Parallelism uint8  = 4
+	argon2SaltLen            = 16
+	argon2KeyLen      uint32 = 32
+)
+
+func hashPassword(password string) (string, error) {
+	salt := make([]byte, argon2SaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("generate salt: %w", err)
+	}
+	hash := argon2.IDKey([]byte(password), salt, argon2Iterations, argon2Memory, argon2Parallelism, argon2KeyLen)
+	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		argon2Memory, argon2Iterations, argon2Parallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash),
+	), nil
+}
+
+func verifyPassword(encodedHash, password string) (bool, error) {
+	parts := strings.Split(encodedHash, "$")
+	if len(parts) != 6 {
+		return false, fmt.Errorf("invalid hash format")
+	}
+	var memory, iterations uint32
+	var parallelism uint8
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &memory, &iterations, &parallelism); err != nil {
+		return false, fmt.Errorf("parse hash params: %w", err)
+	}
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false, fmt.Errorf("decode salt: %w", err)
+	}
+	storedHash, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false, fmt.Errorf("decode hash: %w", err)
+	}
+	computed := argon2.IDKey([]byte(password), salt, iterations, memory, parallelism, uint32(len(storedHash)))
+	return subtle.ConstantTimeCompare(storedHash, computed) == 1, nil
+}

--- a/internal/users/store.go
+++ b/internal/users/store.go
@@ -11,31 +11,31 @@ import (
 )
 
 const userCols = `id, email, name, created_at, updated_at, archived_at`
-const wsMemberCols = `workspace_id, user_id, role, created_at, updated_at, archived_at`
-const projMemberCols = `project_id, user_id, role, created_at, updated_at, archived_at`
 
-// --- User ---
-
-func createUser(ctx context.Context, db *sqlx.DB, p CreateUserParams) (User, error) {
-	var out User
-	err := db.QueryRowxContext(ctx,
-		`INSERT INTO app_users (email, name)
-		 VALUES ($1, $2)
+func createUser(ctx context.Context, db *sqlx.DB, params CreateUserParams) (User, error) {
+	hash, err := hashPassword(params.Password)
+	if err != nil {
+		return User{}, fmt.Errorf("hash password: %w", err)
+	}
+	var user User
+	err = db.QueryRowxContext(ctx,
+		`INSERT INTO app_users (email, name, password_hash)
+		 VALUES ($1, $2, $3)
 		 RETURNING `+userCols,
-		p.Email, p.Name,
-	).StructScan(&out)
+		params.Email, params.Name, hash,
+	).StructScan(&user)
 	if err != nil {
 		if isUniqueViolation(err) {
 			return User{}, ErrDuplicateEmail
 		}
 		return User{}, fmt.Errorf("insert user: %w", err)
 	}
-	return out, nil
+	return user, nil
 }
 
 func getUser(ctx context.Context, db *sqlx.DB, id string) (User, error) {
-	var out User
-	err := db.GetContext(ctx, &out,
+	var user User
+	err := db.GetContext(ctx, &user,
 		`SELECT `+userCols+` FROM app_users WHERE id = $1`,
 		id,
 	)
@@ -45,12 +45,12 @@ func getUser(ctx context.Context, db *sqlx.DB, id string) (User, error) {
 		}
 		return User{}, fmt.Errorf("get user: %w", err)
 	}
-	return out, nil
+	return user, nil
 }
 
 func getUserByEmail(ctx context.Context, db *sqlx.DB, email string) (User, error) {
-	var out User
-	err := db.GetContext(ctx, &out,
+	var user User
+	err := db.GetContext(ctx, &user,
 		`SELECT `+userCols+` FROM app_users WHERE email = $1`,
 		email,
 	)
@@ -60,7 +60,30 @@ func getUserByEmail(ctx context.Context, db *sqlx.DB, email string) (User, error
 		}
 		return User{}, fmt.Errorf("get user by email: %w", err)
 	}
-	return out, nil
+	return user, nil
+}
+
+func authenticateUser(ctx context.Context, db *sqlx.DB, email, password string) (User, error) {
+	var user User
+	err := db.GetContext(ctx, &user,
+		`SELECT `+userCols+`, password_hash FROM app_users WHERE email = $1`,
+		email,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, ErrInvalidCredentials
+		}
+		return User{}, fmt.Errorf("get user for auth: %w", err)
+	}
+	ok, err := verifyPassword(user.PasswordHash, password)
+	if err != nil {
+		return User{}, fmt.Errorf("verify password: %w", err)
+	}
+	if !ok {
+		return User{}, ErrInvalidCredentials
+	}
+	user.PasswordHash = ""
+	return user, nil
 }
 
 func archiveUser(ctx context.Context, db *sqlx.DB, id string) error {
@@ -81,152 +104,6 @@ func archiveUser(ctx context.Context, db *sqlx.DB, id string) error {
 		return ErrUserNotFound
 	}
 	return nil
-}
-
-// --- Workspace members ---
-
-// addWorkspaceMember upserts a workspace member. If the member already exists
-// (even archived), their role is updated and archived_at is cleared.
-func addWorkspaceMember(ctx context.Context, db *sqlx.DB, p AddWorkspaceMemberParams) (WorkspaceMember, error) {
-	var out WorkspaceMember
-	err := db.QueryRowxContext(ctx,
-		`INSERT INTO workspace_members (workspace_id, user_id, role)
-		 VALUES ($1, $2, $3)
-		 ON CONFLICT (workspace_id, user_id)
-		 DO UPDATE SET role = excluded.role, archived_at = NULL
-		 RETURNING `+wsMemberCols,
-		p.WorkspaceID, p.UserID, p.Role,
-	).StructScan(&out)
-	if err != nil {
-		return WorkspaceMember{}, fmt.Errorf("add workspace member: %w", err)
-	}
-	return out, nil
-}
-
-func removeWorkspaceMember(ctx context.Context, db *sqlx.DB, workspaceID, userID string) error {
-	res, err := db.ExecContext(ctx,
-		`UPDATE workspace_members
-		 SET archived_at = NOW()
-		 WHERE workspace_id = $1 AND user_id = $2 AND archived_at IS NULL`,
-		workspaceID, userID,
-	)
-	if err != nil {
-		return fmt.Errorf("remove workspace member: %w", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("remove workspace member rows affected: %w", err)
-	}
-	if n == 0 {
-		return ErrMemberNotFound
-	}
-	return nil
-}
-
-func listWorkspaceMembers(ctx context.Context, db *sqlx.DB, workspaceID string) ([]WorkspaceMember, error) {
-	var out []WorkspaceMember
-	err := db.SelectContext(ctx, &out,
-		`SELECT `+wsMemberCols+`
-		 FROM workspace_members
-		 WHERE workspace_id = $1 AND archived_at IS NULL
-		 ORDER BY created_at ASC`,
-		workspaceID,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("list workspace members: %w", err)
-	}
-	return out, nil
-}
-
-func updateWorkspaceMemberRole(ctx context.Context, db *sqlx.DB, p UpdateWorkspaceMemberRoleParams) (WorkspaceMember, error) {
-	var out WorkspaceMember
-	err := db.QueryRowxContext(ctx,
-		`UPDATE workspace_members
-		 SET role = $1
-		 WHERE workspace_id = $2 AND user_id = $3 AND archived_at IS NULL
-		 RETURNING `+wsMemberCols,
-		p.Role, p.WorkspaceID, p.UserID,
-	).StructScan(&out)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return WorkspaceMember{}, ErrMemberNotFound
-		}
-		return WorkspaceMember{}, fmt.Errorf("update workspace member role: %w", err)
-	}
-	return out, nil
-}
-
-// --- Project members ---
-
-// addProjectMember upserts a project member. If the member already exists
-// (even archived), their role is updated and archived_at is cleared.
-func addProjectMember(ctx context.Context, db *sqlx.DB, p AddProjectMemberParams) (ProjectMember, error) {
-	var out ProjectMember
-	err := db.QueryRowxContext(ctx,
-		`INSERT INTO project_members (project_id, user_id, role)
-		 VALUES ($1, $2, $3)
-		 ON CONFLICT (project_id, user_id)
-		 DO UPDATE SET role = excluded.role, archived_at = NULL
-		 RETURNING `+projMemberCols,
-		p.ProjectID, p.UserID, p.Role,
-	).StructScan(&out)
-	if err != nil {
-		return ProjectMember{}, fmt.Errorf("add project member: %w", err)
-	}
-	return out, nil
-}
-
-func removeProjectMember(ctx context.Context, db *sqlx.DB, projectID, userID string) error {
-	res, err := db.ExecContext(ctx,
-		`UPDATE project_members
-		 SET archived_at = NOW()
-		 WHERE project_id = $1 AND user_id = $2 AND archived_at IS NULL`,
-		projectID, userID,
-	)
-	if err != nil {
-		return fmt.Errorf("remove project member: %w", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("remove project member rows affected: %w", err)
-	}
-	if n == 0 {
-		return ErrMemberNotFound
-	}
-	return nil
-}
-
-func listProjectMembers(ctx context.Context, db *sqlx.DB, projectID string) ([]ProjectMember, error) {
-	var out []ProjectMember
-	err := db.SelectContext(ctx, &out,
-		`SELECT `+projMemberCols+`
-		 FROM project_members
-		 WHERE project_id = $1 AND archived_at IS NULL
-		 ORDER BY created_at ASC`,
-		projectID,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("list project members: %w", err)
-	}
-	return out, nil
-}
-
-func updateProjectMemberRole(ctx context.Context, db *sqlx.DB, p UpdateProjectMemberRoleParams) (ProjectMember, error) {
-	var out ProjectMember
-	err := db.QueryRowxContext(ctx,
-		`UPDATE project_members
-		 SET role = $1
-		 WHERE project_id = $2 AND user_id = $3 AND archived_at IS NULL
-		 RETURNING `+projMemberCols,
-		p.Role, p.ProjectID, p.UserID,
-	).StructScan(&out)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return ProjectMember{}, ErrMemberNotFound
-		}
-		return ProjectMember{}, fmt.Errorf("update project member role: %w", err)
-	}
-	return out, nil
 }
 
 func isUniqueViolation(err error) bool {

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -10,142 +10,48 @@ import (
 )
 
 var (
-	ErrUserNotFound   = errors.New("user not found")
-	ErrDuplicateEmail = errors.New("email already exists")
-	ErrMemberNotFound = errors.New("member not found")
+	ErrUserNotFound       = errors.New("user not found")
+	ErrDuplicateEmail     = errors.New("email already exists")
+	ErrInvalidCredentials = errors.New("invalid credentials")
 )
 
-var validWorkspaceRoles = map[string]bool{"owner": true, "admin": true, "member": true}
-var validProjectRoles = map[string]bool{"admin": true, "member": true, "viewer": true}
-
 type User struct {
-	ID         string     `db:"id"          json:"id"`
-	Email      string     `db:"email"       json:"email"`
-	Name       string     `db:"name"        json:"name"`
-	CreatedAt  time.Time  `db:"created_at"  json:"created_at"`
-	UpdatedAt  time.Time  `db:"updated_at"  json:"updated_at"`
-	ArchivedAt *time.Time `db:"archived_at" json:"archived_at,omitempty"`
-}
-
-type WorkspaceMember struct {
-	WorkspaceID string     `db:"workspace_id" json:"workspace_id"`
-	UserID      string     `db:"user_id"      json:"user_id"`
-	Role        string     `db:"role"         json:"role"`
-	CreatedAt   time.Time  `db:"created_at"   json:"created_at"`
-	UpdatedAt   time.Time  `db:"updated_at"   json:"updated_at"`
-	ArchivedAt  *time.Time `db:"archived_at"  json:"archived_at,omitempty"`
-}
-
-type ProjectMember struct {
-	ProjectID  string     `db:"project_id"  json:"project_id"`
-	UserID     string     `db:"user_id"     json:"user_id"`
-	Role       string     `db:"role"        json:"role"`
-	CreatedAt  time.Time  `db:"created_at"  json:"created_at"`
-	UpdatedAt  time.Time  `db:"updated_at"  json:"updated_at"`
-	ArchivedAt *time.Time `db:"archived_at" json:"archived_at,omitempty"`
+	ID           string     `db:"id"            json:"id"`
+	Email        string     `db:"email"         json:"email"`
+	Name         string     `db:"name"          json:"name"`
+	CreatedAt    time.Time  `db:"created_at"    json:"created_at"`
+	UpdatedAt    time.Time  `db:"updated_at"    json:"updated_at"`
+	ArchivedAt   *time.Time `db:"archived_at"   json:"archived_at,omitempty"`
+	PasswordHash string     `db:"password_hash" json:"-"`
 }
 
 type CreateUserParams struct {
-	Email string
-	Name  string
+	Email    string
+	Name     string
+	Password string
 }
 
-func (p CreateUserParams) Validate() error {
-	if p.Name == "" {
+func (params CreateUserParams) Validate() error {
+	if params.Name == "" {
 		return errors.New("name is required")
 	}
-	if !strings.Contains(p.Email, "@") || p.Email == "" {
+	if !strings.Contains(params.Email, "@") || params.Email == "" {
 		return errors.New("email is required and must contain @")
 	}
-	return nil
-}
-
-type AddWorkspaceMemberParams struct {
-	WorkspaceID string
-	UserID      string
-	Role        string
-}
-
-func (p AddWorkspaceMemberParams) Validate() error {
-	if p.WorkspaceID == "" {
-		return errors.New("workspace_id is required")
-	}
-	if p.UserID == "" {
-		return errors.New("user_id is required")
-	}
-	if !validWorkspaceRoles[p.Role] {
-		return errors.New("role must be 'owner', 'admin' or 'member'")
+	if params.Password == "" {
+		return errors.New("password is required")
 	}
 	return nil
 }
 
-type UpdateWorkspaceMemberRoleParams struct {
-	WorkspaceID string
-	UserID      string
-	Role        string
-}
-
-func (p UpdateWorkspaceMemberRoleParams) Validate() error {
-	if p.WorkspaceID == "" {
-		return errors.New("workspace_id is required")
-	}
-	if p.UserID == "" {
-		return errors.New("user_id is required")
-	}
-	if !validWorkspaceRoles[p.Role] {
-		return errors.New("role must be 'owner', 'admin' or 'member'")
-	}
-	return nil
-}
-
-type AddProjectMemberParams struct {
-	ProjectID string
-	UserID    string
-	Role      string
-}
-
-func (p AddProjectMemberParams) Validate() error {
-	if p.ProjectID == "" {
-		return errors.New("project_id is required")
-	}
-	if p.UserID == "" {
-		return errors.New("user_id is required")
-	}
-	if !validProjectRoles[p.Role] {
-		return errors.New("role must be 'admin', 'member' or 'viewer'")
-	}
-	return nil
-}
-
-type UpdateProjectMemberRoleParams struct {
-	ProjectID string
-	UserID    string
-	Role      string
-}
-
-func (p UpdateProjectMemberRoleParams) Validate() error {
-	if p.ProjectID == "" {
-		return errors.New("project_id is required")
-	}
-	if p.UserID == "" {
-		return errors.New("user_id is required")
-	}
-	if !validProjectRoles[p.Role] {
-		return errors.New("role must be 'admin', 'member' or 'viewer'")
-	}
-	return nil
-}
-
-// --- User ---
-
-func CreateUser(ctx context.Context, db *sqlx.DB, p CreateUserParams) (User, error) {
+func CreateUser(ctx context.Context, db *sqlx.DB, params CreateUserParams) (User, error) {
 	if db == nil {
 		return User{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return User{}, err
 	}
-	return createUser(ctx, db, p)
+	return createUser(ctx, db, params)
 }
 
 func GetUser(ctx context.Context, db *sqlx.DB, id string) (User, error) {
@@ -178,92 +84,12 @@ func ArchiveUser(ctx context.Context, db *sqlx.DB, id string) error {
 	return archiveUser(ctx, db, id)
 }
 
-// --- Workspace members ---
-
-func AddWorkspaceMember(ctx context.Context, db *sqlx.DB, p AddWorkspaceMemberParams) (WorkspaceMember, error) {
+func AuthenticateUser(ctx context.Context, db *sqlx.DB, email, password string) (User, error) {
 	if db == nil {
-		return WorkspaceMember{}, errors.New("db is required")
+		return User{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
-		return WorkspaceMember{}, err
+	if email == "" || password == "" {
+		return User{}, ErrInvalidCredentials
 	}
-	return addWorkspaceMember(ctx, db, p)
-}
-
-func RemoveWorkspaceMember(ctx context.Context, db *sqlx.DB, workspaceID, userID string) error {
-	if db == nil {
-		return errors.New("db is required")
-	}
-	if workspaceID == "" {
-		return errors.New("workspace_id is required")
-	}
-	if userID == "" {
-		return errors.New("user_id is required")
-	}
-	return removeWorkspaceMember(ctx, db, workspaceID, userID)
-}
-
-func ListWorkspaceMembers(ctx context.Context, db *sqlx.DB, workspaceID string) ([]WorkspaceMember, error) {
-	if db == nil {
-		return nil, errors.New("db is required")
-	}
-	if workspaceID == "" {
-		return nil, errors.New("workspace_id is required")
-	}
-	return listWorkspaceMembers(ctx, db, workspaceID)
-}
-
-func UpdateWorkspaceMemberRole(ctx context.Context, db *sqlx.DB, p UpdateWorkspaceMemberRoleParams) (WorkspaceMember, error) {
-	if db == nil {
-		return WorkspaceMember{}, errors.New("db is required")
-	}
-	if err := p.Validate(); err != nil {
-		return WorkspaceMember{}, err
-	}
-	return updateWorkspaceMemberRole(ctx, db, p)
-}
-
-// --- Project members ---
-
-func AddProjectMember(ctx context.Context, db *sqlx.DB, p AddProjectMemberParams) (ProjectMember, error) {
-	if db == nil {
-		return ProjectMember{}, errors.New("db is required")
-	}
-	if err := p.Validate(); err != nil {
-		return ProjectMember{}, err
-	}
-	return addProjectMember(ctx, db, p)
-}
-
-func RemoveProjectMember(ctx context.Context, db *sqlx.DB, projectID, userID string) error {
-	if db == nil {
-		return errors.New("db is required")
-	}
-	if projectID == "" {
-		return errors.New("project_id is required")
-	}
-	if userID == "" {
-		return errors.New("user_id is required")
-	}
-	return removeProjectMember(ctx, db, projectID, userID)
-}
-
-func ListProjectMembers(ctx context.Context, db *sqlx.DB, projectID string) ([]ProjectMember, error) {
-	if db == nil {
-		return nil, errors.New("db is required")
-	}
-	if projectID == "" {
-		return nil, errors.New("project_id is required")
-	}
-	return listProjectMembers(ctx, db, projectID)
-}
-
-func UpdateProjectMemberRole(ctx context.Context, db *sqlx.DB, p UpdateProjectMemberRoleParams) (ProjectMember, error) {
-	if db == nil {
-		return ProjectMember{}, errors.New("db is required")
-	}
-	if err := p.Validate(); err != nil {
-		return ProjectMember{}, err
-	}
-	return updateProjectMemberRole(ctx, db, p)
+	return authenticateUser(ctx, db, email, password)
 }

--- a/internal/users/users_test.go
+++ b/internal/users/users_test.go
@@ -8,64 +8,18 @@ import (
 func TestCreateUserParams_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		p       CreateUserParams
+		params  CreateUserParams
 		wantErr bool
 	}{
-		{name: "valid", p: CreateUserParams{Email: "alice@example.com", Name: "Alice"}, wantErr: false},
-		{name: "missing name", p: CreateUserParams{Email: "alice@example.com", Name: ""}, wantErr: true},
-		{name: "missing email", p: CreateUserParams{Email: "", Name: "Alice"}, wantErr: true},
-		{name: "email without @", p: CreateUserParams{Email: "notanemail", Name: "Alice"}, wantErr: true},
+		{name: "valid", params: CreateUserParams{Email: "alice@example.com", Name: "Alice", Password: "secret"}, wantErr: false},
+		{name: "missing name", params: CreateUserParams{Email: "alice@example.com", Name: "", Password: "secret"}, wantErr: true},
+		{name: "missing email", params: CreateUserParams{Email: "", Name: "Alice", Password: "secret"}, wantErr: true},
+		{name: "email without @", params: CreateUserParams{Email: "notanemail", Name: "Alice", Password: "secret"}, wantErr: true},
+		{name: "missing password", params: CreateUserParams{Email: "alice@example.com", Name: "Alice", Password: ""}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestAddWorkspaceMemberParams_Validate(t *testing.T) {
-	tests := []struct {
-		name    string
-		p       AddWorkspaceMemberParams
-		wantErr bool
-	}{
-		{name: "owner", p: AddWorkspaceMemberParams{WorkspaceID: "w", UserID: "u", Role: "owner"}, wantErr: false},
-		{name: "admin", p: AddWorkspaceMemberParams{WorkspaceID: "w", UserID: "u", Role: "admin"}, wantErr: false},
-		{name: "member", p: AddWorkspaceMemberParams{WorkspaceID: "w", UserID: "u", Role: "member"}, wantErr: false},
-		{name: "missing workspace_id", p: AddWorkspaceMemberParams{WorkspaceID: "", UserID: "u", Role: "member"}, wantErr: true},
-		{name: "missing user_id", p: AddWorkspaceMemberParams{WorkspaceID: "w", UserID: "", Role: "member"}, wantErr: true},
-		{name: "invalid role", p: AddWorkspaceMemberParams{WorkspaceID: "w", UserID: "u", Role: "viewer"}, wantErr: true},
-		{name: "empty role", p: AddWorkspaceMemberParams{WorkspaceID: "w", UserID: "u", Role: ""}, wantErr: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestAddProjectMemberParams_Validate(t *testing.T) {
-	tests := []struct {
-		name    string
-		p       AddProjectMemberParams
-		wantErr bool
-	}{
-		{name: "admin", p: AddProjectMemberParams{ProjectID: "p", UserID: "u", Role: "admin"}, wantErr: false},
-		{name: "member", p: AddProjectMemberParams{ProjectID: "p", UserID: "u", Role: "member"}, wantErr: false},
-		{name: "viewer", p: AddProjectMemberParams{ProjectID: "p", UserID: "u", Role: "viewer"}, wantErr: false},
-		{name: "missing project_id", p: AddProjectMemberParams{ProjectID: "", UserID: "u", Role: "member"}, wantErr: true},
-		{name: "missing user_id", p: AddProjectMemberParams{ProjectID: "p", UserID: "", Role: "member"}, wantErr: true},
-		{name: "invalid role", p: AddProjectMemberParams{ProjectID: "p", UserID: "u", Role: "owner"}, wantErr: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
+			err := tt.params.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -74,7 +28,7 @@ func TestAddProjectMemberParams_Validate(t *testing.T) {
 }
 
 func TestCreateUser_NilDB(t *testing.T) {
-	_, err := CreateUser(context.Background(), nil, CreateUserParams{Email: "a@b.com", Name: "A"})
+	_, err := CreateUser(context.Background(), nil, CreateUserParams{Email: "a@b.com", Name: "A", Password: "p"})
 	if err == nil || err.Error() != "db is required" {
 		t.Fatalf("CreateUser() error = %v, want %q", err, "db is required")
 	}
@@ -101,30 +55,9 @@ func TestArchiveUser_NilDB(t *testing.T) {
 	}
 }
 
-func TestAddWorkspaceMember_NilDB(t *testing.T) {
-	_, err := AddWorkspaceMember(context.Background(), nil, AddWorkspaceMemberParams{WorkspaceID: "w", UserID: "u", Role: "member"})
+func TestAuthenticateUser_NilDB(t *testing.T) {
+	_, err := AuthenticateUser(context.Background(), nil, "a@b.com", "pass")
 	if err == nil || err.Error() != "db is required" {
-		t.Fatalf("AddWorkspaceMember() error = %v, want %q", err, "db is required")
-	}
-}
-
-func TestRemoveWorkspaceMember_NilDB(t *testing.T) {
-	err := RemoveWorkspaceMember(context.Background(), nil, "w", "u")
-	if err == nil || err.Error() != "db is required" {
-		t.Fatalf("RemoveWorkspaceMember() error = %v, want %q", err, "db is required")
-	}
-}
-
-func TestAddProjectMember_NilDB(t *testing.T) {
-	_, err := AddProjectMember(context.Background(), nil, AddProjectMemberParams{ProjectID: "p", UserID: "u", Role: "member"})
-	if err == nil || err.Error() != "db is required" {
-		t.Fatalf("AddProjectMember() error = %v, want %q", err, "db is required")
-	}
-}
-
-func TestRemoveProjectMember_NilDB(t *testing.T) {
-	err := RemoveProjectMember(context.Background(), nil, "p", "u")
-	if err == nil || err.Error() != "db is required" {
-		t.Fatalf("RemoveProjectMember() error = %v, want %q", err, "db is required")
+		t.Fatalf("AuthenticateUser() error = %v, want %q", err, "db is required")
 	}
 }

--- a/internal/workspaces/store.go
+++ b/internal/workspaces/store.go
@@ -11,31 +11,32 @@ import (
 )
 
 const selectCols = `id, name, slug, created_at, updated_at, archived_at`
+const memberCols = `workspace_id, user_id, role, created_at, updated_at, archived_at`
 
-func createWorkspace(ctx context.Context, db *sqlx.DB, p CreateWorkspaceParams) (Workspace, error) {
-	var out Workspace
+func createWorkspace(ctx context.Context, db *sqlx.DB, params CreateWorkspaceParams) (Workspace, error) {
+	var workspace Workspace
 	err := db.QueryRowxContext(
 		ctx,
 		`INSERT INTO workspaces (name, slug)
 		 VALUES ($1, $2)
 		 RETURNING `+selectCols,
-		p.Name,
-		p.Slug,
-	).StructScan(&out)
+		params.Name,
+		params.Slug,
+	).StructScan(&workspace)
 	if err != nil {
 		if isUniqueViolation(err) {
 			return Workspace{}, ErrDuplicateSlug
 		}
 		return Workspace{}, fmt.Errorf("insert workspace: %w", err)
 	}
-	return out, nil
+	return workspace, nil
 }
 
 func getWorkspace(ctx context.Context, db *sqlx.DB, id string) (Workspace, error) {
-	var out Workspace
+	var workspace Workspace
 	err := db.GetContext(
 		ctx,
-		&out,
+		&workspace,
 		`SELECT `+selectCols+`
 		 FROM workspaces
 		 WHERE id = $1`,
@@ -47,14 +48,14 @@ func getWorkspace(ctx context.Context, db *sqlx.DB, id string) (Workspace, error
 		}
 		return Workspace{}, fmt.Errorf("get workspace: %w", err)
 	}
-	return out, nil
+	return workspace, nil
 }
 
 func getWorkspaceBySlug(ctx context.Context, db *sqlx.DB, slug string) (Workspace, error) {
-	var out Workspace
+	var workspace Workspace
 	err := db.GetContext(
 		ctx,
-		&out,
+		&workspace,
 		`SELECT `+selectCols+`
 		 FROM workspaces
 		 WHERE slug = $1`,
@@ -66,7 +67,7 @@ func getWorkspaceBySlug(ctx context.Context, db *sqlx.DB, slug string) (Workspac
 		}
 		return Workspace{}, fmt.Errorf("get workspace by slug: %w", err)
 	}
-	return out, nil
+	return workspace, nil
 }
 
 func archiveWorkspace(ctx context.Context, db *sqlx.DB, id string) error {
@@ -89,6 +90,75 @@ func archiveWorkspace(ctx context.Context, db *sqlx.DB, id string) error {
 		return ErrWorkspaceNotFound
 	}
 	return nil
+}
+
+func addMember(ctx context.Context, db *sqlx.DB, params AddMemberParams) (WorkspaceMember, error) {
+	var member WorkspaceMember
+	err := db.QueryRowxContext(ctx,
+		`INSERT INTO workspace_members (workspace_id, user_id, role)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (workspace_id, user_id)
+		 DO UPDATE SET role = excluded.role, archived_at = NULL
+		 RETURNING `+memberCols,
+		params.WorkspaceID, params.UserID, params.Role,
+	).StructScan(&member)
+	if err != nil {
+		return WorkspaceMember{}, fmt.Errorf("add workspace member: %w", err)
+	}
+	return member, nil
+}
+
+func removeMember(ctx context.Context, db *sqlx.DB, workspaceID, userID string) error {
+	res, err := db.ExecContext(ctx,
+		`UPDATE workspace_members
+		 SET archived_at = NOW()
+		 WHERE workspace_id = $1 AND user_id = $2 AND archived_at IS NULL`,
+		workspaceID, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("remove workspace member: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("remove workspace member rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrMemberNotFound
+	}
+	return nil
+}
+
+func listMembers(ctx context.Context, db *sqlx.DB, workspaceID string) ([]WorkspaceMember, error) {
+	var members []WorkspaceMember
+	err := db.SelectContext(ctx, &members,
+		`SELECT `+memberCols+`
+		 FROM workspace_members
+		 WHERE workspace_id = $1 AND archived_at IS NULL
+		 ORDER BY created_at ASC`,
+		workspaceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace members: %w", err)
+	}
+	return members, nil
+}
+
+func updateMemberRole(ctx context.Context, db *sqlx.DB, params UpdateMemberRoleParams) (WorkspaceMember, error) {
+	var member WorkspaceMember
+	err := db.QueryRowxContext(ctx,
+		`UPDATE workspace_members
+		 SET role = $1
+		 WHERE workspace_id = $2 AND user_id = $3 AND archived_at IS NULL
+		 RETURNING `+memberCols,
+		params.Role, params.WorkspaceID, params.UserID,
+	).StructScan(&member)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WorkspaceMember{}, ErrMemberNotFound
+		}
+		return WorkspaceMember{}, fmt.Errorf("update workspace member role: %w", err)
+	}
+	return member, nil
 }
 
 func isUniqueViolation(err error) bool {

--- a/internal/workspaces/workspaces.go
+++ b/internal/workspaces/workspaces.go
@@ -12,7 +12,10 @@ import (
 var (
 	ErrWorkspaceNotFound = errors.New("workspace not found")
 	ErrDuplicateSlug     = errors.New("slug already exists")
+	ErrMemberNotFound    = errors.New("member not found")
 )
+
+var validRoles = map[string]bool{"owner": true, "admin": true, "member": true}
 
 var reSlug = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,49}$`)
 
@@ -30,24 +33,24 @@ type CreateWorkspaceParams struct {
 	Slug string
 }
 
-func (p CreateWorkspaceParams) Validate() error {
-	if p.Name == "" {
+func (params CreateWorkspaceParams) Validate() error {
+	if params.Name == "" {
 		return errors.New("name is required")
 	}
-	if !reSlug.MatchString(p.Slug) {
+	if !reSlug.MatchString(params.Slug) {
 		return errors.New("slug must be 2-50 lowercase alphanumeric characters or hyphens, starting with a letter or digit")
 	}
 	return nil
 }
 
-func CreateWorkspace(ctx context.Context, db *sqlx.DB, p CreateWorkspaceParams) (Workspace, error) {
+func CreateWorkspace(ctx context.Context, db *sqlx.DB, params CreateWorkspaceParams) (Workspace, error) {
 	if db == nil {
 		return Workspace{}, errors.New("db is required")
 	}
-	if err := p.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return Workspace{}, err
 	}
-	return createWorkspace(ctx, db, p)
+	return createWorkspace(ctx, db, params)
 }
 
 func GetWorkspace(ctx context.Context, db *sqlx.DB, id string) (Workspace, error) {
@@ -68,6 +71,96 @@ func GetWorkspaceBySlug(ctx context.Context, db *sqlx.DB, slug string) (Workspac
 		return Workspace{}, errors.New("slug is required")
 	}
 	return getWorkspaceBySlug(ctx, db, slug)
+}
+
+type WorkspaceMember struct {
+	WorkspaceID string     `db:"workspace_id" json:"workspace_id"`
+	UserID      string     `db:"user_id"      json:"user_id"`
+	Role        string     `db:"role"         json:"role"`
+	CreatedAt   time.Time  `db:"created_at"   json:"created_at"`
+	UpdatedAt   time.Time  `db:"updated_at"   json:"updated_at"`
+	ArchivedAt  *time.Time `db:"archived_at"  json:"archived_at,omitempty"`
+}
+
+type AddMemberParams struct {
+	WorkspaceID string
+	UserID      string
+	Role        string
+}
+
+func (params AddMemberParams) Validate() error {
+	if params.WorkspaceID == "" {
+		return errors.New("workspace_id is required")
+	}
+	if params.UserID == "" {
+		return errors.New("user_id is required")
+	}
+	if !validRoles[params.Role] {
+		return errors.New("role must be 'owner', 'admin' or 'member'")
+	}
+	return nil
+}
+
+type UpdateMemberRoleParams struct {
+	WorkspaceID string
+	UserID      string
+	Role        string
+}
+
+func (params UpdateMemberRoleParams) Validate() error {
+	if params.WorkspaceID == "" {
+		return errors.New("workspace_id is required")
+	}
+	if params.UserID == "" {
+		return errors.New("user_id is required")
+	}
+	if !validRoles[params.Role] {
+		return errors.New("role must be 'owner', 'admin' or 'member'")
+	}
+	return nil
+}
+
+func AddMember(ctx context.Context, db *sqlx.DB, params AddMemberParams) (WorkspaceMember, error) {
+	if db == nil {
+		return WorkspaceMember{}, errors.New("db is required")
+	}
+	if err := params.Validate(); err != nil {
+		return WorkspaceMember{}, err
+	}
+	return addMember(ctx, db, params)
+}
+
+func RemoveMember(ctx context.Context, db *sqlx.DB, workspaceID, userID string) error {
+	if db == nil {
+		return errors.New("db is required")
+	}
+	if workspaceID == "" {
+		return errors.New("workspace_id is required")
+	}
+	if userID == "" {
+		return errors.New("user_id is required")
+	}
+	return removeMember(ctx, db, workspaceID, userID)
+}
+
+func ListMembers(ctx context.Context, db *sqlx.DB, workspaceID string) ([]WorkspaceMember, error) {
+	if db == nil {
+		return nil, errors.New("db is required")
+	}
+	if workspaceID == "" {
+		return nil, errors.New("workspace_id is required")
+	}
+	return listMembers(ctx, db, workspaceID)
+}
+
+func UpdateMemberRole(ctx context.Context, db *sqlx.DB, params UpdateMemberRoleParams) (WorkspaceMember, error) {
+	if db == nil {
+		return WorkspaceMember{}, errors.New("db is required")
+	}
+	if err := params.Validate(); err != nil {
+		return WorkspaceMember{}, err
+	}
+	return updateMemberRole(ctx, db, params)
 }
 
 func ArchiveWorkspace(ctx context.Context, db *sqlx.DB, id string) error {

--- a/internal/workspaces/workspaces_test.go
+++ b/internal/workspaces/workspaces_test.go
@@ -8,59 +8,59 @@ import (
 func TestCreateWorkspaceParams_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		p       CreateWorkspaceParams
+		params  CreateWorkspaceParams
 		wantErr bool
 	}{
 		{
 			name:    "valid",
-			p:       CreateWorkspaceParams{Name: "Acme Corp", Slug: "acme-corp"},
+			params:  CreateWorkspaceParams{Name: "Acme Corp", Slug: "acme-corp"},
 			wantErr: false,
 		},
 		{
 			name:    "slug exactly 2 chars",
-			p:       CreateWorkspaceParams{Name: "AB", Slug: "ab"},
+			params:  CreateWorkspaceParams{Name: "AB", Slug: "ab"},
 			wantErr: false,
 		},
 		{
 			name:    "slug with digits",
-			p:       CreateWorkspaceParams{Name: "Team 42", Slug: "team42"},
+			params:  CreateWorkspaceParams{Name: "Team 42", Slug: "team42"},
 			wantErr: false,
 		},
 		{
 			name:    "missing name",
-			p:       CreateWorkspaceParams{Name: "", Slug: "acme"},
+			params:  CreateWorkspaceParams{Name: "", Slug: "acme"},
 			wantErr: true,
 		},
 		{
 			name:    "slug too short",
-			p:       CreateWorkspaceParams{Name: "A", Slug: "a"},
+			params:  CreateWorkspaceParams{Name: "A", Slug: "a"},
 			wantErr: true,
 		},
 		{
 			name:    "slug with uppercase",
-			p:       CreateWorkspaceParams{Name: "Acme", Slug: "Acme"},
+			params:  CreateWorkspaceParams{Name: "Acme", Slug: "Acme"},
 			wantErr: true,
 		},
 		{
 			name:    "slug starts with hyphen",
-			p:       CreateWorkspaceParams{Name: "Acme", Slug: "-acme"},
+			params:  CreateWorkspaceParams{Name: "Acme", Slug: "-acme"},
 			wantErr: true,
 		},
 		{
 			name:    "slug with spaces",
-			p:       CreateWorkspaceParams{Name: "Acme", Slug: "acme corp"},
+			params:  CreateWorkspaceParams{Name: "Acme", Slug: "acme corp"},
 			wantErr: true,
 		},
 		{
 			name:    "empty slug",
-			p:       CreateWorkspaceParams{Name: "Acme", Slug: ""},
+			params:  CreateWorkspaceParams{Name: "Acme", Slug: ""},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate()
+			err := tt.params.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/migrations/0002_add_password_hash_to_users.up.sql
+++ b/migrations/0002_add_password_hash_to_users.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_users ADD COLUMN password_hash TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

  - Add Argon2id password hashing and `POST /auth/login` endpoint (401 on invalid credentials)
  - Move `WorkspaceMember` to `workspaces` package and `ProjectMember` to `projects` package — each domain owns its own
  membership logic
  - Extract `hashPassword`/`verifyPassword` to dedicated `password.go`
  - Rename cryptic variables to descriptive names across all packages (`p → params`, `u → user`, `out → <type>`, `m →
  member`, `proj → project`)
  - Wire frontend: localStorage session store, route guard on `/(app)`, login form with error display, logout in nav

  ## Breaking Changes

  - `POST /users` now requires a `password` field
  - Migration required: `0002_add_password_hash_to_users.up.sql` (adds `password_hash` column)