### PR TITLE
feat(sessions): add session storage foundation with hashed tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,19 @@ front/.idea
 # macOS
 .DS_Store
 
+# Go build artifacts
+server
+*.exe
+*.test
+*.out
+/bin/
+/dist/
+
 # Docker data directories
 .docker/
+
+# Local development and planning files
+AGENTS.md
+plans/
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,27 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 ## [Unreleased]
 
 ### Added
+- Added session storage foundation (`internal/sessions`): `Create`, `Validate`, `Delete`
+- Added SHA-256 token hashing — raw tokens never stored in the database
+- Added archived-user rejection in session validation (`ErrUserArchived`)
+- Added migration `0003_create_sessions` with indexes on `user_id` and `expires_at`
+- Added workspace-scoped URL routing (`/{workspace}/...`)
+- Added Kanban and Scrum project templates with localized status names per user language
+- Added project creation wizard: step 1 template selection, step 2 name and key
+- Added empty states with action buttons across all pages (no workspace, no projects, no boards, no statuses)
+- Added settings page with language switcher
+- Added projects overview dashboard at `/{workspace}/`
 - Added a root changelog to track notable project changes
 - Added a README link to the changelog
+
+### Changed
+- Changed workspace creation to add creator as owner member in a single transaction
+- Changed sidebar workspace selection to sync via URL navigation instead of local state
+- Changed board view to sync statuses on navigation via `$effect`
+
+### Fixed
+- Fixed Go nil slice serialization returning JSON `null` instead of `[]`
+- Fixed board not updating when switching between projects
 
 ---
 

--- a/docs/01-product-scope.md
+++ b/docs/01-product-scope.md
@@ -72,7 +72,7 @@ What exists in the codebase today:
 **Not yet shipped:**
 
 - Drag-and-drop board UI (backend ready; frontend not wired).
-- Cookie-based auth and authorization enforcement (`POST /api/auth/login` exists; full session management and per-handler enforcement are not yet shipped).
+- Cookie-based auth and authorization enforcement (`POST /api/auth/login` exists; session storage layer shipped with hashed tokens and archived-user rejection; middleware, cookie handling, and per-handler enforcement are not yet shipped).
 - Wiki/documentation pages.
 - Full methodology customization (custom fields per issue, configurable transition rules, richer workflow rules).
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -153,7 +153,8 @@ Each `handler.go` defines a local `fail(w, err)` function that maps domain senti
 
 - `POST /api/auth/login` exists and returns a user payload on success.
 - The frontend currently stores the returned user object in **local storage**.
-- Full cookie-based session management, a logout endpoint, and per-handler permission enforcement are **not yet implemented**.
+- Session storage layer shipped: `internal/sessions` with `Create`, `Validate`, `Delete`. Tokens are SHA-256 hashed before storage; archived users are rejected on validation.
+- Cookie-based session middleware, auth endpoints (`/auth/me`, `/auth/logout`), and per-handler membership enforcement are **not yet implemented** (PRs 2–6 of Phase 1).
 
 ### Target
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -44,8 +44,15 @@ The core platform infrastructure and first working end-to-end flow.
 
 Close the gap between what the backend supports and what the UI delivers. Deliver a fully usable, secure baseline.
 
-- **Full cookie-based authentication**: server-side sessions with `HttpOnly`, `Secure`, `SameSite=Strict` cookies; logout endpoint; replace current local storage approach.
-- **Membership enforcement**: workspace and project membership validated per handler using the session context.
+**Authentication and authorization** (6-PR delivery plan):
+- PR 1 `[shipped]` — Session storage foundation: `internal/sessions` with `Create`, `Validate`, `Delete`. SHA-256 hashed tokens. Archived-user rejection. Migration `0003_create_sessions`.
+- PR 2 `[pending]` — Auth middleware (`withAuth`) and endpoints: `POST /auth/login` (cookie), `GET /auth/me`, `POST /auth/logout`. Self-only `GET /users/{userID}`.
+- PR 3 `[pending]` — Membership authorization: `internal/authz` with context helpers and workspace membership enforcement on member-level routes.
+- PR 4 `[pending]` — Remove client-controlled identity: drop `owner_id`, `reporter_id`, `user_id` from API contracts; derive from session.
+- PR 5 `[pending]` — Admin/owner authorization for workspace and project administration.
+- PR 6 `[pending]` — Frontend session migration (replace auth localStorage with `/auth/me`) and workflow configuration admin enforcement.
+
+**Other Phase 1 items:**
 - **Board UI — drag-and-drop**: wire the frontend to `MoveIssue`; issues move between columns with correct position updates.
 - **Issue detail page**: view and edit title, description, priority, assignee, due date.
 - **Basic board filters**: filter by assignee, priority, and issue type.

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -1,0 +1,101 @@
+package sessions
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+var (
+	ErrSessionNotFound = errors.New("session not found")
+	ErrSessionExpired  = errors.New("session expired")
+	ErrUserArchived    = errors.New("user account is archived")
+)
+
+// DefaultSessionTTL is the default time-to-live for a session (7 days)
+const DefaultSessionTTL = 7 * 24 * time.Hour
+
+// Session represents a user session.
+// ID is the hashed token stored in the database, not the raw bearer token.
+type Session struct {
+	ID         string     `db:"id"           json:"id"`
+	UserID     string     `db:"user_id"      json:"user_id"`
+	CreatedAt  time.Time  `db:"created_at"   json:"created_at"`
+	ExpiresAt  time.Time  `db:"expires_at"   json:"expires_at"`
+	LastUsedAt *time.Time `db:"last_used_at" json:"last_used_at,omitempty"`
+}
+
+// GenerateToken generates a cryptographically random 32-byte session token
+// encoded as a hex string.
+func GenerateToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// HashToken returns the SHA-256 hex digest of a raw token.
+// The hash is what gets stored in the database; the raw token is the bearer
+// credential returned to the client.
+func HashToken(raw string) string {
+	h := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(h[:])
+}
+
+// Create creates a new session for the given user.
+// It returns the Session whose ID is the hashed token. The raw token is
+// available only at creation time via the second return value of
+// createSession (the caller of this function receives it in Session.ID
+// temporarily replaced — see store.go for details).
+//
+// The caller must capture the raw token from CreateResult and send it to
+// the client; it cannot be recovered from the database.
+func Create(ctx context.Context, db *sqlx.DB, userID string) (CreateResult, error) {
+	if db == nil {
+		return CreateResult{}, errors.New("db is required")
+	}
+	if userID == "" {
+		return CreateResult{}, errors.New("userID is required")
+	}
+	return createSession(ctx, db, userID, DefaultSessionTTL)
+}
+
+// CreateResult holds both the persisted session and the raw (unhashed)
+// token that must be sent to the client exactly once.
+type CreateResult struct {
+	Session  Session
+	RawToken string
+}
+
+// Validate validates a session by its raw token.
+// The token is hashed before lookup. Returns ErrSessionNotFound if the
+// session does not exist, ErrSessionExpired if expired, or ErrUserArchived
+// if the owning user account has been archived.
+func Validate(ctx context.Context, db *sqlx.DB, token string) (Session, error) {
+	if db == nil {
+		return Session{}, errors.New("db is required")
+	}
+	if token == "" {
+		return Session{}, errors.New("token is required")
+	}
+	return validateSession(ctx, db, token)
+}
+
+// Delete deletes a session by its raw token.
+// The token is hashed before lookup.
+// Does not return an error if the session does not exist (idempotent).
+func Delete(ctx context.Context, db *sqlx.DB, token string) error {
+	if db == nil {
+		return errors.New("db is required")
+	}
+	if token == "" {
+		return errors.New("token is required")
+	}
+	return deleteSession(ctx, db, token)
+}

--- a/internal/sessions/sessions_test.go
+++ b/internal/sessions/sessions_test.go
@@ -1,0 +1,114 @@
+package sessions
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// fakeDB returns a non-nil *sqlx.DB that is not connected to any database.
+// Useful for exercising validation branches that check parameters before
+// touching the database.
+func fakeDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	raw, err := sql.Open("postgres", "")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	return sqlx.NewDb(raw, "postgres")
+}
+
+func TestGenerateToken(t *testing.T) {
+	token1, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	if len(token1) != 64 { // 32 bytes = 64 hex characters
+		t.Fatalf("GenerateToken() length = %d, want 64", len(token1))
+	}
+
+	token2, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	if token1 == token2 {
+		t.Fatalf("GenerateToken() generated identical tokens")
+	}
+}
+
+func TestHashToken(t *testing.T) {
+	token := "abc123"
+	h1 := HashToken(token)
+	h2 := HashToken(token)
+	if h1 != h2 {
+		t.Fatalf("HashToken() not deterministic: %q != %q", h1, h2)
+	}
+	if len(h1) != 64 { // SHA-256 = 32 bytes = 64 hex chars
+		t.Fatalf("HashToken() length = %d, want 64", len(h1))
+	}
+	if h1 == token {
+		t.Fatal("HashToken() returned the raw token")
+	}
+}
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name    string
+		db      *sqlx.DB
+		userID  string
+		wantErr string
+	}{
+		{name: "nil db", db: nil, userID: "u1", wantErr: "db is required"},
+		{name: "empty userID", db: fakeDB(t), userID: "", wantErr: "userID is required"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Create(context.Background(), tc.db, tc.userID)
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("Create() error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		db      *sqlx.DB
+		token   string
+		wantErr string
+	}{
+		{name: "nil db", db: nil, token: "tok", wantErr: "db is required"},
+		{name: "empty token", db: fakeDB(t), token: "", wantErr: "token is required"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Validate(context.Background(), tc.db, tc.token)
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("Validate() error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tests := []struct {
+		name    string
+		db      *sqlx.DB
+		token   string
+		wantErr string
+	}{
+		{name: "nil db", db: nil, token: "tok", wantErr: "db is required"},
+		{name: "empty token", db: fakeDB(t), token: "", wantErr: "token is required"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Delete(context.Background(), tc.db, tc.token)
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("Delete() error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -1,0 +1,84 @@
+package sessions
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+const sessionCols = `s.id, s.user_id, s.created_at, s.expires_at, s.last_used_at`
+
+func createSession(ctx context.Context, db *sqlx.DB, userID string, ttl time.Duration) (CreateResult, error) {
+	rawToken, err := GenerateToken()
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("generate token: %w", err)
+	}
+
+	hashedToken := HashToken(rawToken)
+	now := time.Now()
+	expiresAt := now.Add(ttl)
+
+	var session Session
+	err = db.QueryRowxContext(ctx,
+		`INSERT INTO sessions (id, user_id, created_at, expires_at, last_used_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 RETURNING id, user_id, created_at, expires_at, last_used_at`,
+		hashedToken, userID, now, expiresAt, now,
+	).StructScan(&session)
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("insert session: %w", err)
+	}
+	return CreateResult{Session: session, RawToken: rawToken}, nil
+}
+
+func validateSession(ctx context.Context, db *sqlx.DB, rawToken string) (Session, error) {
+	hashedToken := HashToken(rawToken)
+
+	var session Session
+	err := db.GetContext(ctx, &session,
+		`SELECT `+sessionCols+`
+		 FROM sessions s
+		 JOIN app_users u ON u.id = s.user_id
+		 WHERE s.id = $1
+		   AND u.archived_at IS NULL`,
+		hashedToken,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Distinguish "session missing" from "user archived":
+			// check if the session row exists at all.
+			var exists bool
+			if err2 := db.GetContext(ctx, &exists,
+				`SELECT EXISTS(SELECT 1 FROM sessions WHERE id = $1)`, hashedToken); err2 != nil {
+				return Session{}, fmt.Errorf("check session existence: %w", err2)
+			}
+			if exists {
+				return Session{}, ErrUserArchived
+			}
+			return Session{}, ErrSessionNotFound
+		}
+		return Session{}, fmt.Errorf("get session: %w", err)
+	}
+
+	if time.Now().After(session.ExpiresAt) {
+		return Session{}, ErrSessionExpired
+	}
+
+	return session, nil
+}
+
+func deleteSession(ctx context.Context, db *sqlx.DB, rawToken string) error {
+	hashedToken := HashToken(rawToken)
+	_, err := db.ExecContext(ctx,
+		`DELETE FROM sessions WHERE id = $1`,
+		hashedToken,
+	)
+	if err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+	return nil
+}

--- a/internal/sessions/store_integration_test.go
+++ b/internal/sessions/store_integration_test.go
@@ -1,0 +1,273 @@
+package sessions
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+	"github.com/start-codex/taskcode/internal/testpg"
+	"github.com/start-codex/taskcode/internal/users"
+)
+
+func TestCreateSession(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+
+	tests := []struct {
+		name    string
+		arrange func(*testing.T, *sqlx.DB) (string, func(*testing.T))
+		wantErr error
+	}{
+		{
+			name: "creates session successfully",
+			arrange: func(t *testing.T, db *sqlx.DB) (string, func(*testing.T)) {
+				u := seedUser(t, db)
+				return u.ID, func(t *testing.T) {}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID, check := tt.arrange(t, db)
+			got, err := Create(context.Background(), db, userID)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Create() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if err == nil {
+				if got.RawToken == "" {
+					t.Fatal("expected non-empty raw token")
+				}
+				if len(got.RawToken) != 64 {
+					t.Fatalf("raw token length = %d, want 64", len(got.RawToken))
+				}
+				// Session.ID should be the hash, not the raw token
+				if got.Session.ID == got.RawToken {
+					t.Fatal("session ID should be hashed, not raw token")
+				}
+				if got.Session.ID != HashToken(got.RawToken) {
+					t.Fatal("session ID should equal HashToken(rawToken)")
+				}
+				if got.Session.UserID != userID {
+					t.Fatalf("user_id: got %q, want %q", got.Session.UserID, userID)
+				}
+				if got.Session.CreatedAt.IsZero() {
+					t.Fatal("expected non-zero created_at")
+				}
+				if got.Session.ExpiresAt.IsZero() {
+					t.Fatal("expected non-zero expires_at")
+				}
+				if got.Session.LastUsedAt == nil || got.Session.LastUsedAt.IsZero() {
+					t.Fatal("expected non-zero last_used_at")
+				}
+				expectedExpiry := time.Now().Add(DefaultSessionTTL)
+				if got.Session.ExpiresAt.Before(expectedExpiry.Add(-time.Minute)) || got.Session.ExpiresAt.After(expectedExpiry.Add(time.Minute)) {
+					t.Fatalf("expires_at: got %v, want approximately %v", got.Session.ExpiresAt, expectedExpiry)
+				}
+			}
+			if check != nil {
+				check(t)
+			}
+		})
+	}
+}
+
+func TestValidateSession(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+
+	tests := []struct {
+		name    string
+		arrange func(*testing.T, *sqlx.DB) (string, func(*testing.T))
+		wantErr error
+	}{
+		{
+			name: "validates existing session",
+			arrange: func(t *testing.T, db *sqlx.DB) (string, func(*testing.T)) {
+				result := seedSession(t, db)
+				return result.RawToken, func(t *testing.T) {}
+			},
+		},
+		{
+			name:    "session not found",
+			wantErr: ErrSessionNotFound,
+			arrange: func(t *testing.T, db *sqlx.DB) (string, func(*testing.T)) {
+				return "nonexistent-token-that-does-not-exist-in-database-00000000", nil
+			},
+		},
+		{
+			name:    "session expired",
+			wantErr: ErrSessionExpired,
+			arrange: func(t *testing.T, db *sqlx.DB) (string, func(*testing.T)) {
+				u := seedUser(t, db)
+				result, err := createSession(context.Background(), db, u.ID, -time.Hour)
+				if err != nil {
+					t.Fatalf("create expired session: %v", err)
+				}
+				t.Cleanup(func() {
+					db.ExecContext(context.Background(), `DELETE FROM sessions WHERE id = $1`, result.Session.ID)
+				})
+				return result.RawToken, nil
+			},
+		},
+		{
+			name:    "user archived",
+			wantErr: ErrUserArchived,
+			arrange: func(t *testing.T, db *sqlx.DB) (string, func(*testing.T)) {
+				u := seedUser(t, db)
+				result, err := createSession(context.Background(), db, u.ID, DefaultSessionTTL)
+				if err != nil {
+					t.Fatalf("create session: %v", err)
+				}
+				// Archive the user
+				_, err = db.ExecContext(context.Background(),
+					`UPDATE app_users SET archived_at = NOW() WHERE id = $1`, u.ID)
+				if err != nil {
+					t.Fatalf("archive user: %v", err)
+				}
+				t.Cleanup(func() {
+					db.ExecContext(context.Background(), `DELETE FROM sessions WHERE id = $1`, result.Session.ID)
+					db.ExecContext(context.Background(), `UPDATE app_users SET archived_at = NULL WHERE id = $1`, u.ID)
+				})
+				return result.RawToken, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, check := tt.arrange(t, db)
+			got, err := Validate(context.Background(), db, token)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if err == nil {
+				if got.ID != HashToken(token) {
+					t.Fatalf("session id: got %q, want hash of token", got.ID)
+				}
+			}
+			if check != nil {
+				check(t)
+			}
+		})
+	}
+}
+
+func TestDeleteSession(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+
+	tests := []struct {
+		name    string
+		arrange func(*testing.T, *sqlx.DB) string
+		wantErr error
+	}{
+		{
+			name: "deletes existing session",
+			arrange: func(t *testing.T, db *sqlx.DB) string {
+				result := seedSession(t, db)
+				return result.RawToken
+			},
+		},
+		{
+			name: "idempotent for nonexistent session",
+			arrange: func(t *testing.T, db *sqlx.DB) string {
+				return "nonexistent-token-00000000000000000000000000000000000000"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := tt.arrange(t, db)
+			err := Delete(context.Background(), db, token)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Delete() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+
+			_, err = Validate(context.Background(), db, token)
+			if !errors.Is(err, ErrSessionNotFound) {
+				t.Fatalf("after Delete(), Validate() error = %v, want ErrSessionNotFound", err)
+			}
+		})
+	}
+}
+
+func TestSessionLifecycle(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+
+	u := seedUser(t, db)
+
+	// Create session
+	result, err := Create(context.Background(), db, u.ID)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	rawToken := result.RawToken
+	t.Cleanup(func() {
+		db.ExecContext(context.Background(), `DELETE FROM sessions WHERE id = $1`, result.Session.ID)
+	})
+
+	// Validate session using raw token
+	validated, err := Validate(context.Background(), db, rawToken)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if validated.ID != HashToken(rawToken) {
+		t.Fatalf("validated session id: got %q, want hash of raw token", validated.ID)
+	}
+
+	// Delete session using raw token
+	err = Delete(context.Background(), db, rawToken)
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	// Verify session is deleted
+	_, err = Validate(context.Background(), db, rawToken)
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("after Delete(), Validate() error = %v, want ErrSessionNotFound", err)
+	}
+
+	// Delete again (idempotent)
+	err = Delete(context.Background(), db, rawToken)
+	if err != nil {
+		t.Fatalf("Delete() second time error = %v, want nil (idempotent)", err)
+	}
+}
+
+// --- helpers ---
+
+func seedUser(t *testing.T, db *sqlx.DB) users.User {
+	t.Helper()
+	suffix := testpg.UniqueSuffix(t, db)
+	u, err := users.CreateUser(context.Background(), db, users.CreateUserParams{
+		Email:    "session-test-" + suffix + "@test.local",
+		Name:     "Session Test User",
+		Password: "testpass123",
+	})
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		db.ExecContext(context.Background(), `DELETE FROM app_users WHERE id = $1`, u.ID)
+	})
+	return u
+}
+
+func seedSession(t *testing.T, db *sqlx.DB) CreateResult {
+	t.Helper()
+	u := seedUser(t, db)
+	result, err := Create(context.Background(), db, u.ID)
+	if err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	t.Cleanup(func() {
+		db.ExecContext(context.Background(), `DELETE FROM sessions WHERE id = $1`, result.Session.ID)
+	})
+	return result
+}

--- a/migrations/0003_create_sessions.down.sql
+++ b/migrations/0003_create_sessions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sessions;

--- a/migrations/0003_create_sessions.up.sql
+++ b/migrations/0003_create_sessions.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE sessions (
+    id           TEXT PRIMARY KEY,
+    user_id      UUID NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at   TIMESTAMPTZ NOT NULL,
+    last_used_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);


### PR DESCRIPTION
## Summary
- Add `internal/sessions` package: `Create`, `Validate`, `Delete`
- SHA-256 hashed tokens — raw tokens never stored in the database
- Reject sessions for archived users (`ErrUserArchived`)
- Migration `0003_create_sessions` with indexes on `user_id` and `expires_at`
- Update CHANGELOG, roadmap, product scope, and architecture docs

## PR 1 of 6 — Auth delivery plan
This is the first PR in the authentication and membership enforcement plan (Phase 1).
Next: PR 2 — Auth middleware and endpoints.

## Test plan
- [x] `go test -count=1 ./internal/sessions/` passes
- [x] `go test -count=1 ./internal/...` passes
- [x] No middleware, cookies, handlers, or frontend changes included