### PR TITLE
feat(authz): remove client-controlled identity from API contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 - Changed `GET /users/{userID}` to enforce self-only access (403 on mismatch)
 - Changed login to reject archived users before session creation
 - Changed `internal/authctx` consolidated into `internal/authz`
-- Changed `POST /workspaces` to reject `owner_id` that doesn't match authenticated user
+- Changed `POST /workspaces` to derive owner from authenticated session (removed `owner_id` from request body)
+- Changed `GET /workspaces` to derive user from authenticated session (removed `user_id` query parameter)
+- Changed `POST /projects/{projectID}/issues` to derive reporter from authenticated session (removed `reporter_id` from request body)
 - Changed authz resource resolution to allow archived projects, boards, and columns (domain handlers decide visibility)
 - Changed project name from Taskcore to Traza Work (domain: trazawork.com)
 - Changed license from AGPL-3.0 to BSL 1.1

--- a/cmd/server/authz_routes_test.go
+++ b/cmd/server/authz_routes_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -197,6 +198,233 @@ func TestAuthzWiring_BoardGet(t *testing.T) {
 	env = doRequest(t, srv, "GET", "/boards/"+boardID, nonMemberToken)
 	if env.Status != 403 {
 		t.Fatalf("non-member GET /boards/{id}: status = %d, want 403", env.Status)
+	}
+}
+
+type dataEnvelope struct {
+	Status int             `json:"status"`
+	Data   json.RawMessage `json:"data,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+func doRequestWithBody(t *testing.T, srv *httptest.Server, method, path, token string, body any) dataEnvelope {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+	}
+	req, err := http.NewRequest(method, srv.URL+path, &buf)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: "session_id", Value: token})
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	var env dataEnvelope
+	_ = json.NewDecoder(resp.Body).Decode(&env)
+	env.Status = resp.StatusCode
+	return env
+}
+
+// TestContractCleanup_WorkspaceCreate verifies POST /workspaces derives owner
+// from session and ignores any spoofed owner_id in the body.
+func TestContractCleanup_WorkspaceCreate(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	userID := testpg.SeedUser(t, db)
+	token := loginCookie(t, db, userID)
+	suffix := testpg.UniqueSuffix(t, db)
+
+	// Create workspace without owner_id
+	env := doRequestWithBody(t, srv, "POST", "/workspaces", token, map[string]string{
+		"name": "WS " + suffix,
+		"slug": "ws-" + suffix,
+	})
+	if env.Status != 201 {
+		t.Fatalf("POST /workspaces without owner_id: status = %d, want 201 (error: %s)", env.Status, env.Error)
+	}
+
+	// Verify the authenticated user became the owner
+	var ws struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(env.Data, &ws); err != nil {
+		t.Fatalf("unmarshal workspace: %v", err)
+	}
+	var role string
+	err := db.QueryRowContext(context.Background(),
+		`SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2`,
+		ws.ID, userID,
+	).Scan(&role)
+	if err != nil {
+		t.Fatalf("query owner membership: %v", err)
+	}
+	if role != "owner" {
+		t.Fatalf("owner role = %q, want %q", role, "owner")
+	}
+
+	// Spoofed owner_id should be ignored — user still becomes owner
+	otherUser := testpg.SeedUser(t, db)
+	suffix2 := testpg.UniqueSuffix(t, db)
+	env = doRequestWithBody(t, srv, "POST", "/workspaces", token, map[string]string{
+		"name":     "WS " + suffix2,
+		"slug":     "ws-" + suffix2,
+		"owner_id": otherUser,
+	})
+	if env.Status != 201 {
+		t.Fatalf("POST /workspaces with spoofed owner_id: status = %d, want 201 (error: %s)", env.Status, env.Error)
+	}
+	var ws2 struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(env.Data, &ws2); err != nil {
+		t.Fatalf("unmarshal workspace: %v", err)
+	}
+	err = db.QueryRowContext(context.Background(),
+		`SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2`,
+		ws2.ID, userID,
+	).Scan(&role)
+	if err != nil {
+		t.Fatalf("query owner membership after spoof: %v", err)
+	}
+	if role != "owner" {
+		t.Fatalf("spoofed owner_id: authenticated user role = %q, want %q", role, "owner")
+	}
+}
+
+// TestContractCleanup_WorkspaceList verifies GET /workspaces derives user
+// from session, returns only the authenticated user's workspaces, and ignores
+// any spoofed user_id query parameter.
+func TestContractCleanup_WorkspaceList(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	member := testpg.SeedUser(t, db)
+	other := testpg.SeedUser(t, db)
+
+	// Create two workspaces: one with member, one with other only
+	memberWS := testpg.SeedWorkspace(t, db)
+	otherWS := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, memberWS, member, "member")
+	seedMember(t, db, otherWS, other, "member")
+
+	token := loginCookie(t, db, member)
+
+	assertOnlyMemberWorkspace := func(t *testing.T, path string) {
+		t.Helper()
+
+		env := doRequestWithBody(t, srv, "GET", path, token, nil)
+		if env.Status != 200 {
+			t.Fatalf("GET %s: status = %d, want 200 (error: %s)", path, env.Status, env.Error)
+		}
+
+		var wsList []struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(env.Data, &wsList); err != nil {
+			t.Fatalf("unmarshal workspace list for %s: %v", path, err)
+		}
+		if len(wsList) != 1 {
+			t.Fatalf("GET %s returned %d workspaces, want 1", path, len(wsList))
+		}
+		if wsList[0].ID != memberWS {
+			t.Fatalf("GET %s returned workspace %s, want %s", path, wsList[0].ID, memberWS)
+		}
+		if wsList[0].ID == otherWS {
+			t.Fatalf("GET %s returned other user's workspace %s", path, otherWS)
+		}
+	}
+
+	// GET /workspaces → should return only member's workspace
+	assertOnlyMemberWorkspace(t, "/workspaces")
+
+	// GET /workspaces?user_id=other → query param ignored, still returns member's workspace only
+	assertOnlyMemberWorkspace(t, "/workspaces?user_id="+other)
+}
+
+// TestContractCleanup_IssueCreate verifies POST /projects/{id}/issues derives
+// reporter from session and ignores any spoofed reporter_id.
+func TestContractCleanup_IssueCreate(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	member := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, member, "member")
+	projID := testpg.SeedProject(t, db, wsID, "ISRC")
+	token := loginCookie(t, db, member)
+
+	// Seed a status and issue type for the project
+	var statusID, issueTypeID string
+	err := db.QueryRowContext(context.Background(),
+		`INSERT INTO statuses (project_id, name, category, position) VALUES ($1, 'Todo', 'todo', 0) RETURNING id`,
+		projID,
+	).Scan(&statusID)
+	if err != nil {
+		t.Fatalf("seed status: %v", err)
+	}
+	err = db.QueryRowContext(context.Background(),
+		`INSERT INTO issue_types (project_id, name, icon, level) VALUES ($1, 'Task', 'task', 0) RETURNING id`,
+		projID,
+	).Scan(&issueTypeID)
+	if err != nil {
+		t.Fatalf("seed issue type: %v", err)
+	}
+
+	// Create issue without reporter_id
+	env := doRequestWithBody(t, srv, "POST", "/projects/"+projID+"/issues", token, map[string]string{
+		"issue_type_id": issueTypeID,
+		"status_id":     statusID,
+		"title":         "Test issue",
+	})
+	if env.Status != 201 {
+		t.Fatalf("POST /issues without reporter_id: status = %d, want 201 (error: %s)", env.Status, env.Error)
+	}
+
+	var issue struct {
+		ID         string `json:"id"`
+		ReporterID string `json:"reporter_id"`
+	}
+	if err := json.Unmarshal(env.Data, &issue); err != nil {
+		t.Fatalf("unmarshal issue: %v", err)
+	}
+	if issue.ReporterID != member {
+		t.Fatalf("reporter_id = %q, want %q (authenticated user)", issue.ReporterID, member)
+	}
+
+	// Spoofed reporter_id should be ignored
+	otherUser := testpg.SeedUser(t, db)
+	env = doRequestWithBody(t, srv, "POST", "/projects/"+projID+"/issues", token, map[string]string{
+		"issue_type_id": issueTypeID,
+		"status_id":     statusID,
+		"title":         "Spoofed issue",
+		"reporter_id":   otherUser,
+	})
+	if env.Status != 201 {
+		t.Fatalf("POST /issues with spoofed reporter_id: status = %d, want 201 (error: %s)", env.Status, env.Error)
+	}
+	var issue2 struct {
+		ReporterID string `json:"reporter_id"`
+	}
+	if err := json.Unmarshal(env.Data, &issue2); err != nil {
+		t.Fatalf("unmarshal issue: %v", err)
+	}
+	if issue2.ReporterID != member {
+		t.Fatalf("spoofed reporter_id: got %q, want %q (authenticated user)", issue2.ReporterID, member)
 	}
 }
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -48,7 +48,7 @@ Close the gap between what the backend supports and what the UI delivers. Delive
 - PR 1 `[shipped]` — Session storage foundation: `internal/sessions` with `Create`, `Validate`, `Delete`. SHA-256 hashed tokens. Archived-user rejection. Migration `0003_create_sessions`.
 - PR 2 `[shipped]` — Auth middleware (`withAuth`) and endpoints: `POST /auth/login` (cookie), `GET /auth/me`, `POST /auth/logout`. Self-only `GET /users/{userID}`.
 - PR 3 `[shipped]` — Membership authorization: `internal/authz` with context helpers and workspace membership enforcement on all API routes (read and write). Consolidated `internal/authctx` into `internal/authz`.
-- PR 4 `[pending]` — Remove client-controlled identity: drop `owner_id`, `reporter_id`, `user_id` from API contracts; derive from session.
+- PR 4 `[shipped]` — Remove client-controlled identity: drop `owner_id`, `reporter_id`, `user_id` from API contracts; derive from session.
 - PR 5 `[pending]` — Admin/owner authorization for workspace and project administration.
 - PR 6 `[pending]` — Frontend session migration (replace auth localStorage with `/auth/me`) and workflow configuration admin enforcement.
 

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -46,10 +46,10 @@ export const users = {
 
 // --- Workspaces ---
 export const workspaces = {
-	create: (body: { name: string; slug: string; owner_id: string }) => post<Workspace>('/workspaces', body),
+	create: (body: { name: string; slug: string }) => post<Workspace>('/workspaces', body),
 	get: (workspaceID: string) => get<Workspace>(`/workspaces/${workspaceID}`),
 	archive: (workspaceID: string) => del(`/workspaces/${workspaceID}`),
-	listByUser: (userID: string) => get<Workspace[]>(`/workspaces?user_id=${userID}`),
+	list: () => get<Workspace[]>('/workspaces'),
 	members: {
 		list: (workspaceID: string) => get<WorkspaceMember[]>(`/workspaces/${workspaceID}/members`),
 		add: (workspaceID: string, body: { user_id: string; role: string }) =>
@@ -184,7 +184,7 @@ export interface Issue {
 }
 export interface CreateIssueBody {
 	issue_type_id: string; status_id: string; title: string;
-	reporter_id: string; description?: string; priority?: string;
+	description?: string; priority?: string;
 	assignee_id?: string; parent_issue_id?: string; due_date?: string;
 }
 export interface UpdateIssueBody {

--- a/front/src/lib/components/team-switcher.svelte
+++ b/front/src/lib/components/team-switcher.svelte
@@ -76,7 +76,7 @@
 		error = '';
 		saving = true;
 		try {
-			const workspace = await workspacesApi.create({ name: name.trim(), slug: slug.trim(), owner_id: $currentUser!.id });
+			const workspace = await workspacesApi.create({ name: name.trim(), slug: slug.trim() });
 			sheetOpen = false;
 			resetForm();
 			onCreate?.(workspace);

--- a/front/src/routes/(app)/+page.svelte
+++ b/front/src/routes/(app)/+page.svelte
@@ -40,7 +40,7 @@
 		const user = $currentUser;
 		if (!user) { goto('/login'); return; }
 		try {
-			const list = await workspacesApi.listByUser(user.id);
+			const list = await workspacesApi.list();
 			if (list && list.length > 0) {
 				goto(`/${list[0].slug}`);
 				return;
@@ -61,7 +61,7 @@
 		wsError = '';
 		wsSaving = true;
 		try {
-			const ws = await workspacesApi.create({ name: wsName.trim(), slug: wsSlug.trim(), owner_id: $currentUser!.id });
+			const ws = await workspacesApi.create({ name: wsName.trim(), slug: wsSlug.trim() });
 			goto(`/${ws.slug}`);
 		} catch (err) {
 			wsError = err instanceof Error ? err.message : 'Failed to create workspace';

--- a/front/src/routes/(app)/[workspace]/+layout.ts
+++ b/front/src/routes/(app)/[workspace]/+layout.ts
@@ -13,7 +13,7 @@ export const load: LayoutLoad = async ({ params }) => {
 	if (!raw) redirect(302, '/login');
 
 	const user = JSON.parse(raw);
-	const list = await workspacesApi.listByUser(user.id).catch(() => []);
+	const list = await workspacesApi.list().catch(() => []);
 	const workspace = list.find((w) => w.slug === params.workspace);
 
 	if (!workspace) redirect(302, '/');

--- a/internal/issues/handler.go
+++ b/internal/issues/handler.go
@@ -49,6 +49,11 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			fail(w, err)
 			return
 		}
+		authedUserID, err := authz.UserIDFromContext(r.Context())
+		if err != nil {
+			fail(w, err)
+			return
+		}
 		var body struct {
 			IssueTypeID   string `json:"issue_type_id"`
 			StatusID      string `json:"status_id"`
@@ -57,7 +62,6 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			Description   string `json:"description"`
 			Priority      string `json:"priority"`
 			AssigneeID    string `json:"assignee_id"`
-			ReporterID    string `json:"reporter_id"`
 		}
 		if err := respond.Decode(r, &body); err != nil {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
@@ -72,7 +76,7 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			Description:   body.Description,
 			Priority:      body.Priority,
 			AssigneeID:    body.AssigneeID,
-			ReporterID:    body.ReporterID,
+			ReporterID:    authedUserID,
 		}
 		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())

--- a/internal/workspaces/handler.go
+++ b/internal/workspaces/handler.go
@@ -50,22 +50,14 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			return
 		}
 		var body struct {
-			Name    string `json:"name"`
-			Slug    string `json:"slug"`
-			OwnerID string `json:"owner_id"`
+			Name string `json:"name"`
+			Slug string `json:"slug"`
 		}
 		if err := respond.Decode(r, &body); err != nil {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
-		if body.OwnerID != "" && body.OwnerID != authedUserID {
-			respond.Error(w, http.StatusForbidden, "owner_id must match authenticated user")
-			return
-		}
-		if body.OwnerID == "" {
-			body.OwnerID = authedUserID
-		}
-		params := CreateWorkspaceParams{Name: body.Name, Slug: body.Slug, OwnerID: body.OwnerID}
+		params := CreateWorkspaceParams{Name: body.Name, Slug: body.Slug, OwnerID: authedUserID}
 		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
@@ -209,9 +201,9 @@ func handleRemoveMember(db *sqlx.DB) http.HandlerFunc {
 
 func handleListByUser(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		userID := r.URL.Query().Get("user_id")
-		if userID == "" {
-			respond.Error(w, http.StatusBadRequest, "user_id query param is required")
+		userID, err := authz.UserIDFromContext(r.Context())
+		if err != nil {
+			fail(w, err)
 			return
 		}
 		workspaceList, err := ListByUser(r.Context(), db, userID)


### PR DESCRIPTION
## Summary
- Drop `owner_id` from `POST /workspaces` — owner derived from authenticated session
- Drop `user_id` query param from `GET /workspaces` — user derived from session
- Drop `reporter_id` from `POST /projects/{id}/issues` — reporter derived from session
- Frontend API client and call sites updated to match new contracts
- Integration tests verify session-derived identity and spoof rejection

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./internal/...`
- [x] `go test -count=1 ./cmd/server/...`
- [x] `pnpm --dir front check`
- [x] Manual: create workspace → authenticated user is owner
- [x] Manual: create issue → authenticated user is reporter
- [x] Manual: workspace list returns only session user's workspaces