### PR TITLE
feat(authz): add admin/owner authorization for workspace and project administration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 - Added workspace membership enforcement on all API routes (read and write)
 - Added project-member creation guard: target user must be a workspace member
 - Added `sessions.IsAuthError` helper for centralized error classification
+- Added `RequireWorkspaceAdmin` to `internal/authz` for admin/owner role enforcement
 - Added BSL 1.1 license (replaces AGPL-3.0) with Apache 2.0 change license after 4 years per version
 - Added Contributor License Agreement (CLA.md)
 - Added Contributing guide (CONTRIBUTING.md)
@@ -42,6 +43,8 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 - Changed `POST /workspaces` to derive owner from authenticated session (removed `owner_id` from request body)
 - Changed `GET /workspaces` to derive user from authenticated session (removed `user_id` query parameter)
 - Changed `POST /projects/{projectID}/issues` to derive reporter from authenticated session (removed `reporter_id` from request body)
+- Changed workspace admin routes (`DELETE /workspaces/{id}`, member management) to require admin/owner role
+- Changed project admin routes (`POST /workspaces/{id}/projects`, `DELETE /projects/{id}`, member management) to require workspace admin/owner role
 - Changed authz resource resolution to allow archived projects, boards, and columns (domain handlers decide visibility)
 - Changed project name from Taskcore to Traza Work (domain: trazawork.com)
 - Changed license from AGPL-3.0 to BSL 1.1

--- a/cmd/server/authz_routes_test.go
+++ b/cmd/server/authz_routes_test.go
@@ -428,5 +428,218 @@ func TestContractCleanup_IssueCreate(t *testing.T) {
 	}
 }
 
+// TestAdminWiring_WorkspaceArchive verifies DELETE /workspaces/{id}
+// returns 403 for members and 204 for admins.
+func TestAdminWiring_WorkspaceArchive(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	admin := testpg.SeedUser(t, db)
+	member := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, admin, "admin")
+	seedMember(t, db, wsID, member, "member")
+
+	memberToken := loginCookie(t, db, member)
+	adminToken := loginCookie(t, db, admin)
+
+	// Member → 403
+	env := doRequest(t, srv, "DELETE", "/workspaces/"+wsID, memberToken)
+	if env.Status != 403 {
+		t.Fatalf("member DELETE /workspaces/{id}: status = %d, want 403", env.Status)
+	}
+
+	// Admin → 204
+	env = doRequest(t, srv, "DELETE", "/workspaces/"+wsID, adminToken)
+	if env.Status != 204 {
+		t.Fatalf("admin DELETE /workspaces/{id}: status = %d, want 204 (error: %s)", env.Status, env.Error)
+	}
+}
+
+// TestAdminWiring_WorkspaceMembers verifies GET/POST /workspaces/{id}/members
+// returns 403 for members and success for admins.
+func TestAdminWiring_WorkspaceMembers(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	admin := testpg.SeedUser(t, db)
+	member := testpg.SeedUser(t, db)
+	newUser := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, admin, "admin")
+	seedMember(t, db, wsID, member, "member")
+
+	memberToken := loginCookie(t, db, member)
+	adminToken := loginCookie(t, db, admin)
+
+	// Member GET /workspaces/{id}/members → 403
+	env := doRequest(t, srv, "GET", "/workspaces/"+wsID+"/members", memberToken)
+	if env.Status != 403 {
+		t.Fatalf("member GET /workspaces/{id}/members: status = %d, want 403", env.Status)
+	}
+
+	// Admin GET /workspaces/{id}/members → 200
+	env = doRequest(t, srv, "GET", "/workspaces/"+wsID+"/members", adminToken)
+	if env.Status != 200 {
+		t.Fatalf("admin GET /workspaces/{id}/members: status = %d, want 200 (error: %s)", env.Status, env.Error)
+	}
+
+	// Member POST /workspaces/{id}/members → 403
+	envD := doRequestWithBody(t, srv, "POST", "/workspaces/"+wsID+"/members", memberToken, map[string]string{
+		"user_id": newUser, "role": "member",
+	})
+	if envD.Status != 403 {
+		t.Fatalf("member POST /workspaces/{id}/members: status = %d, want 403", envD.Status)
+	}
+
+	// Admin POST /workspaces/{id}/members → 201
+	envD = doRequestWithBody(t, srv, "POST", "/workspaces/"+wsID+"/members", adminToken, map[string]string{
+		"user_id": newUser, "role": "member",
+	})
+	if envD.Status != 201 {
+		t.Fatalf("admin POST /workspaces/{id}/members: status = %d, want 201 (error: %s)", envD.Status, envD.Error)
+	}
+}
+
+// TestAdminWiring_ProjectCreate verifies POST /workspaces/{id}/projects
+// returns 403 for members and 201 for admins.
+func TestAdminWiring_ProjectCreate(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	admin := testpg.SeedUser(t, db)
+	member := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, admin, "admin")
+	seedMember(t, db, wsID, member, "member")
+
+	memberToken := loginCookie(t, db, member)
+	adminToken := loginCookie(t, db, admin)
+
+	suffix := testpg.UniqueSuffix(t, db)
+
+	// Member → 403
+	envD := doRequestWithBody(t, srv, "POST", "/workspaces/"+wsID+"/projects", memberToken, map[string]string{
+		"name": "Proj " + suffix, "key": "PM" + suffix[:2],
+	})
+	if envD.Status != 403 {
+		t.Fatalf("member POST /workspaces/{id}/projects: status = %d, want 403", envD.Status)
+	}
+
+	// Admin → 201
+	envD = doRequestWithBody(t, srv, "POST", "/workspaces/"+wsID+"/projects", adminToken, map[string]string{
+		"name": "Proj " + suffix, "key": "PA" + suffix[:2],
+	})
+	if envD.Status != 201 {
+		t.Fatalf("admin POST /workspaces/{id}/projects: status = %d, want 201 (error: %s)", envD.Status, envD.Error)
+	}
+}
+
+// TestAdminWiring_ProjectArchive verifies DELETE /projects/{id}
+// returns 403 for members and 204 for admins.
+func TestAdminWiring_ProjectArchive(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	admin := testpg.SeedUser(t, db)
+	member := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, admin, "admin")
+	seedMember(t, db, wsID, member, "member")
+	projID := testpg.SeedProject(t, db, wsID, "PADL")
+
+	memberToken := loginCookie(t, db, member)
+	adminToken := loginCookie(t, db, admin)
+
+	// Member → 403
+	env := doRequest(t, srv, "DELETE", "/projects/"+projID, memberToken)
+	if env.Status != 403 {
+		t.Fatalf("member DELETE /projects/{id}: status = %d, want 403", env.Status)
+	}
+
+	// Admin → 204
+	env = doRequest(t, srv, "DELETE", "/projects/"+projID, adminToken)
+	if env.Status != 204 {
+		t.Fatalf("admin DELETE /projects/{id}: status = %d, want 204 (error: %s)", env.Status, env.Error)
+	}
+}
+
+// TestAdminWiring_ProjectMembers verifies GET/POST /projects/{id}/members
+// returns 403 for members and success for admins.
+func TestAdminWiring_ProjectMembers(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	admin := testpg.SeedUser(t, db)
+	member := testpg.SeedUser(t, db)
+	newUser := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, admin, "admin")
+	seedMember(t, db, wsID, member, "member")
+	seedMember(t, db, wsID, newUser, "member")
+	projID := testpg.SeedProject(t, db, wsID, "PMBR")
+
+	memberToken := loginCookie(t, db, member)
+	adminToken := loginCookie(t, db, admin)
+
+	// Member GET /projects/{id}/members → 403
+	env := doRequest(t, srv, "GET", "/projects/"+projID+"/members", memberToken)
+	if env.Status != 403 {
+		t.Fatalf("member GET /projects/{id}/members: status = %d, want 403", env.Status)
+	}
+
+	// Admin GET /projects/{id}/members → 200
+	env = doRequest(t, srv, "GET", "/projects/"+projID+"/members", adminToken)
+	if env.Status != 200 {
+		t.Fatalf("admin GET /projects/{id}/members: status = %d, want 200 (error: %s)", env.Status, env.Error)
+	}
+
+	// Member POST /projects/{id}/members → 403
+	envD := doRequestWithBody(t, srv, "POST", "/projects/"+projID+"/members", memberToken, map[string]string{
+		"user_id": newUser, "role": "member",
+	})
+	if envD.Status != 403 {
+		t.Fatalf("member POST /projects/{id}/members: status = %d, want 403", envD.Status)
+	}
+
+	// Admin POST /projects/{id}/members → 201
+	envD = doRequestWithBody(t, srv, "POST", "/projects/"+projID+"/members", adminToken, map[string]string{
+		"user_id": newUser, "role": "member",
+	})
+	if envD.Status != 201 {
+		t.Fatalf("admin POST /projects/{id}/members: status = %d, want 201 (error: %s)", envD.Status, envD.Error)
+	}
+}
+
+// TestAdminWiring_MemberReadNoRegression verifies GET /workspaces/{id} and
+// GET /projects/{id} still return 200 for members (not broken by admin checks).
+func TestAdminWiring_MemberReadNoRegression(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	member := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, member, "member")
+	projID := testpg.SeedProject(t, db, wsID, "NREG")
+
+	token := loginCookie(t, db, member)
+
+	env := doRequest(t, srv, "GET", "/workspaces/"+wsID, token)
+	if env.Status != 200 {
+		t.Fatalf("member GET /workspaces/{id}: status = %d, want 200", env.Status)
+	}
+
+	env = doRequest(t, srv, "GET", "/projects/"+projID, token)
+	if env.Status != 200 {
+		t.Fatalf("member GET /projects/{id}: status = %d, want 200", env.Status)
+	}
+}
+
 // Ensure authz import is used (it's needed for the test to compile with the right module).
 var _ = authz.ErrForbidden

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -49,7 +49,7 @@ Close the gap between what the backend supports and what the UI delivers. Delive
 - PR 2 `[shipped]` — Auth middleware (`withAuth`) and endpoints: `POST /auth/login` (cookie), `GET /auth/me`, `POST /auth/logout`. Self-only `GET /users/{userID}`.
 - PR 3 `[shipped]` — Membership authorization: `internal/authz` with context helpers and workspace membership enforcement on all API routes (read and write). Consolidated `internal/authctx` into `internal/authz`.
 - PR 4 `[shipped]` — Remove client-controlled identity: drop `owner_id`, `reporter_id`, `user_id` from API contracts; derive from session.
-- PR 5 `[pending]` — Admin/owner authorization for workspace and project administration.
+- PR 5 `[shipped]` — Admin/owner authorization for workspace and project administration.
 - PR 6 `[pending]` — Frontend session migration (replace auth localStorage with `/auth/me`) and workflow configuration admin enforcement.
 
 **Other Phase 1 items:**

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -70,6 +70,37 @@ func RequireWorkspaceMembership(ctx context.Context, db *sqlx.DB, workspaceID st
 	return nil
 }
 
+// RequireWorkspaceAdmin verifies that the authenticated user has admin or owner
+// role in the given workspace. Returns ErrWorkspaceNotFound if the workspace
+// does not exist (or is archived), ErrForbidden if the user is not admin/owner.
+func RequireWorkspaceAdmin(ctx context.Context, db *sqlx.DB, workspaceID string) error {
+	if db == nil {
+		return errors.New("db is required")
+	}
+	if workspaceID == "" {
+		return errors.New("workspaceID is required")
+	}
+	userID, err := UserIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	exists, err := workspaceExists(ctx, db, workspaceID)
+	if err != nil {
+		return fmt.Errorf("require workspace admin: %w", err)
+	}
+	if !exists {
+		return ErrWorkspaceNotFound
+	}
+	role, err := memberRole(ctx, db, workspaceID, userID)
+	if err != nil {
+		return err
+	}
+	if role != "admin" && role != "owner" {
+		return ErrForbidden
+	}
+	return nil
+}
+
 // RequireProjectMembership verifies that the authenticated user is a member
 // of the workspace that owns the given project. Returns the resolved
 // workspaceID on success.

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -95,6 +95,34 @@ func TestRequireWorkspaceMembership_NoContext(t *testing.T) {
 	}
 }
 
+func TestRequireWorkspaceAdmin_Guards(t *testing.T) {
+	ctx := WithUserID(context.Background(), "user-1")
+	tests := []struct {
+		name        string
+		db          *sqlx.DB
+		workspaceID string
+		wantErr     string
+	}{
+		{name: "nil db", db: nil, workspaceID: "ws-1", wantErr: "db is required"},
+		{name: "empty workspaceID", db: fakeDB(t), workspaceID: "", wantErr: "workspaceID is required"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireWorkspaceAdmin(ctx, tc.db, tc.workspaceID)
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequireWorkspaceAdmin_NoContext(t *testing.T) {
+	err := RequireWorkspaceAdmin(context.Background(), fakeDB(t), "ws-1")
+	if !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("error = %v, want ErrUnauthenticated", err)
+	}
+}
+
 func TestRequireProjectMembership_Guards(t *testing.T) {
 	ctx := WithUserID(context.Background(), "user-1")
 	tests := []struct {

--- a/internal/authz/store.go
+++ b/internal/authz/store.go
@@ -37,6 +37,21 @@ func isMember(ctx context.Context, db *sqlx.DB, workspaceID, userID string) (boo
 	return exists, nil
 }
 
+func memberRole(ctx context.Context, db *sqlx.DB, workspaceID, userID string) (string, error) {
+	var role string
+	err := db.GetContext(ctx, &role,
+		`SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2 AND archived_at IS NULL`,
+		workspaceID, userID,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", ErrForbidden
+		}
+		return "", fmt.Errorf("get member role: %w", err)
+	}
+	return role, nil
+}
+
 func projectWorkspaceID(ctx context.Context, db *sqlx.DB, projectID string) (string, error) {
 	var wsID string
 	err := db.GetContext(ctx, &wsID,

--- a/internal/authz/store_integration_test.go
+++ b/internal/authz/store_integration_test.go
@@ -103,6 +103,79 @@ func TestRequireWorkspaceMembership_ArchivedWorkspace(t *testing.T) {
 	}
 }
 
+func TestMemberRole_Integration(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+
+	owner := testpg.SeedUser(t, db)
+	admin := testpg.SeedUser(t, db)
+	member := testpg.SeedUser(t, db)
+	nonMember := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, owner, "owner")
+	seedMember(t, db, wsID, admin, "admin")
+	seedMember(t, db, wsID, member, "member")
+
+	tests := []struct {
+		name     string
+		userID   string
+		wantRole string
+		wantErr  error
+	}{
+		{name: "owner", userID: owner, wantRole: "owner"},
+		{name: "admin", userID: admin, wantRole: "admin"},
+		{name: "member", userID: member, wantRole: "member"},
+		{name: "non-member", userID: nonMember, wantErr: ErrForbidden},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role, err := memberRole(context.Background(), db, wsID, tt.userID)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if err == nil && role != tt.wantRole {
+				t.Fatalf("role = %q, want %q", role, tt.wantRole)
+			}
+		})
+	}
+}
+
+func TestRequireWorkspaceAdmin_Integration(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+
+	owner := testpg.SeedUser(t, db)
+	admin := testpg.SeedUser(t, db)
+	member := testpg.SeedUser(t, db)
+	nonMember := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, owner, "owner")
+	seedMember(t, db, wsID, admin, "admin")
+	seedMember(t, db, wsID, member, "member")
+
+	tests := []struct {
+		name    string
+		userID  string
+		wsID    string
+		wantErr error
+	}{
+		{name: "owner ok", userID: owner, wsID: wsID},
+		{name: "admin ok", userID: admin, wsID: wsID},
+		{name: "member forbidden", userID: member, wsID: wsID, wantErr: ErrForbidden},
+		{name: "non-member forbidden", userID: nonMember, wsID: wsID, wantErr: ErrForbidden},
+		{name: "workspace not found", userID: owner, wsID: "00000000-0000-0000-0000-000000000000", wantErr: ErrWorkspaceNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithUserID(context.Background(), tt.userID)
+			err := RequireWorkspaceAdmin(ctx, db, tt.wsID)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestRequireProjectMembership_Integration(t *testing.T) {
 	db := testpg.Open(t)
 	testpg.EnsureMigrated(t, db)

--- a/internal/projects/handler.go
+++ b/internal/projects/handler.go
@@ -46,7 +46,7 @@ func fail(w http.ResponseWriter, err error) {
 func handleCreate(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wsID := r.PathValue("workspaceID")
-		if err := authz.RequireWorkspaceMembership(r.Context(), db, wsID); err != nil {
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -117,7 +117,12 @@ func handleGet(db *sqlx.DB) http.HandlerFunc {
 func handleArchive(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projID := r.PathValue("projectID")
-		if _, err := authz.RequireProjectMembership(r.Context(), db, projID); err != nil {
+		wsID, err := authz.RequireProjectMembership(r.Context(), db, projID)
+		if err != nil {
+			fail(w, err)
+			return
+		}
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -132,7 +137,12 @@ func handleArchive(db *sqlx.DB) http.HandlerFunc {
 func handleListMembers(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projID := r.PathValue("projectID")
-		if _, err := authz.RequireProjectMembership(r.Context(), db, projID); err != nil {
+		wsID, err := authz.RequireProjectMembership(r.Context(), db, projID)
+		if err != nil {
+			fail(w, err)
+			return
+		}
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -150,6 +160,10 @@ func handleAddMember(db *sqlx.DB) http.HandlerFunc {
 		projID := r.PathValue("projectID")
 		wsID, err := authz.RequireProjectMembership(r.Context(), db, projID)
 		if err != nil {
+			fail(w, err)
+			return
+		}
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -188,7 +202,12 @@ func handleAddMember(db *sqlx.DB) http.HandlerFunc {
 func handleUpdateMemberRole(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projID := r.PathValue("projectID")
-		if _, err := authz.RequireProjectMembership(r.Context(), db, projID); err != nil {
+		wsID, err := authz.RequireProjectMembership(r.Context(), db, projID)
+		if err != nil {
+			fail(w, err)
+			return
+		}
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -220,11 +239,16 @@ func handleUpdateMemberRole(db *sqlx.DB) http.HandlerFunc {
 func handleRemoveMember(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projID := r.PathValue("projectID")
-		if _, err := authz.RequireProjectMembership(r.Context(), db, projID); err != nil {
+		wsID, err := authz.RequireProjectMembership(r.Context(), db, projID)
+		if err != nil {
 			fail(w, err)
 			return
 		}
-		err := RemoveMember(r.Context(), db, projID, r.PathValue("userID"))
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
+			fail(w, err)
+			return
+		}
+		err = RemoveMember(r.Context(), db, projID, r.PathValue("userID"))
 		if err != nil {
 			fail(w, err)
 			return

--- a/internal/workspaces/handler.go
+++ b/internal/workspaces/handler.go
@@ -90,7 +90,7 @@ func handleGet(db *sqlx.DB) http.HandlerFunc {
 func handleArchive(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wsID := r.PathValue("workspaceID")
-		if err := authz.RequireWorkspaceMembership(r.Context(), db, wsID); err != nil {
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -105,7 +105,7 @@ func handleArchive(db *sqlx.DB) http.HandlerFunc {
 func handleListMembers(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wsID := r.PathValue("workspaceID")
-		if err := authz.RequireWorkspaceMembership(r.Context(), db, wsID); err != nil {
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -121,7 +121,7 @@ func handleListMembers(db *sqlx.DB) http.HandlerFunc {
 func handleAddMember(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wsID := r.PathValue("workspaceID")
-		if err := authz.RequireWorkspaceMembership(r.Context(), db, wsID); err != nil {
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -154,7 +154,7 @@ func handleAddMember(db *sqlx.DB) http.HandlerFunc {
 func handleUpdateMemberRole(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wsID := r.PathValue("workspaceID")
-		if err := authz.RequireWorkspaceMembership(r.Context(), db, wsID); err != nil {
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}
@@ -186,7 +186,7 @@ func handleUpdateMemberRole(db *sqlx.DB) http.HandlerFunc {
 func handleRemoveMember(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wsID := r.PathValue("workspaceID")
-		if err := authz.RequireWorkspaceMembership(r.Context(), db, wsID); err != nil {
+		if err := authz.RequireWorkspaceAdmin(r.Context(), db, wsID); err != nil {
 			fail(w, err)
 			return
 		}


### PR DESCRIPTION
## Summary
- Add `RequireWorkspaceAdmin` to `internal/authz` — enforces admin/owner role via `workspace_members.role`
- Apply admin check on workspace routes: archive, member list/add/update/remove
- Apply admin check on project routes: create, archive, member list/add/update/remove
- Members now receive `403` on all administrative actions
- Read-only routes (`GET /workspaces/{id}`, `GET /projects/{id}`) remain member-level

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./internal/...`
- [x] `go test -count=1 ./cmd/server/...`
- [x] Manual: member tries DELETE /workspaces/{id} → 403
- [x] Manual: admin DELETE /workspaces/{id} → 204
- [x] Manual: member tries POST /workspaces/{id}/projects → 403
- [x] Manual: admin POST /workspaces/{id}/projects → 201
- [x] Manual: member GET /workspaces/{id} → 200 (no regression)