### PR TITLE
chore: rebrand from Traza Work to Tookly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This file tracks notable changes to Traza Work.
+This file tracks notable changes to Tookly.
 
 The project does not use tagged releases yet. Until versioning starts, history is recorded using an `Unreleased` section for ongoing work, plus dated milestone entries for committed historical work.
 
@@ -46,7 +46,7 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 - Changed workspace admin routes (`DELETE /workspaces/{id}`, member management) to require admin/owner role
 - Changed project admin routes (`POST /workspaces/{id}/projects`, `DELETE /projects/{id}`, member management) to require workspace admin/owner role
 - Changed authz resource resolution to allow archived projects, boards, and columns (domain handlers decide visibility)
-- Changed project name from Taskcore to Traza Work (domain: trazawork.com)
+- Changed project name from Taskcore to Traza Work, then to Tookly
 - Changed license from AGPL-3.0 to BSL 1.1
 - Changed workspace creation to add creator as owner member in a single transaction
 - Changed sidebar workspace selection to sync via URL navigation instead of local state

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # Contributor License Agreement
 
-Thank you for your interest in contributing to Traza Work, a project owned and maintained by Start Codex ("Company").
+Thank you for your interest in contributing to Tookly, a project owned and maintained by Start Codex ("Company").
 
 By submitting a contribution (via pull request, patch, or any other mechanism) to this repository, you agree to the following terms. Start Codex SAS (NIT 901599365-2), registered in Aguachica, Cesar, Colombia.
 
@@ -32,7 +32,7 @@ You understand that the decision to include your Contribution in any product or 
 
 ## 6. Dual Licensing
 
-You acknowledge that the Company may license the project (including your Contributions) under additional license terms, including commercial or proprietary licenses, for use in products and services offered by the Company (such as Traza Work Cloud). Your Contribution will always remain available under the project's source-available license (currently BSL 1.1, converting to Apache 2.0 after the change date) in this repository.
+You acknowledge that the Company may license the project (including your Contributions) under additional license terms, including commercial or proprietary licenses, for use in products and services offered by the Company (such as Tookly Cloud). Your Contribution will always remain available under the project's source-available license (currently BSL 1.1, converting to Apache 2.0 after the change date) in this repository.
 
 ## 7. How to Sign
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
-# Contributing to Traza Work
+# Contributing to Tookly
 
-We welcome contributions to Traza Work. Before you start, please review this guide.
+We welcome contributions to Tookly. Before you start, please review this guide.
 
 ## Contributor License Agreement
 
-All contributors must agree to our [Contributor License Agreement](CLA.md) before their first pull request can be merged. This is required because Traza Work is dual-licensed:
+All contributors must agree to our [Contributor License Agreement](CLA.md) before their first pull request can be merged. This is required because Tookly is dual-licensed:
 
-- **Traza Work** is available under [BSL 1.1](LICENSE) — free to use, modify, and self-host. Converts to Apache 2.0 after 4 years per version.
-- **Traza Work Cloud** is a commercial SaaS product maintained by Start Codex SAS, built on top of Traza Work.
+- **Tookly** is available under [BSL 1.1](LICENSE) — free to use, modify, and self-host. Converts to Apache 2.0 after 4 years per version.
+- **Tookly Cloud** is a commercial SaaS product maintained by Start Codex SAS, built on top of Tookly.
 
-The CLA ensures that contributions to the open source project can also be included in Traza Work Cloud. Your contribution will always remain available under BSL 1.1 in this repository.
+The CLA ensures that contributions to the open source project can also be included in Tookly Cloud. Your contribution will always remain available under BSL 1.1 in this repository.
 
 When you open your first pull request, the CLA Assistant bot will ask you to sign. This is a one-time step.
 

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Parameters
 
 Licensor:             Start Codex SAS (NIT 901599365-2)
                       Aguachica, Cesar, Colombia
-Licensed Work:        Traza Work
+Licensed Work:        Tookly
                       The Licensed Work is (c) 2025 Start Codex SAS.
 
 Additional Use Grant: You may make use of the Licensed Work, provided that

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help db-up db-down db-logs db-shell migrate-up migrate-down migrate-status migrate-create
 
 # Default database URL
-DB_URL ?= postgres://trazawork:trazawork@localhost:5432/trazawork?sslmode=disable
+DB_URL ?= postgres://tookly:tookly@localhost:5432/tookly?sslmode=disable
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -13,7 +13,7 @@ help: ## Show this help
 db-up: ## Start PostgreSQL database
 	docker compose up -d db
 	@echo "Waiting for database to be ready..."
-	@docker compose exec db pg_isready -U trazawork -d trazawork --timeout=30 || (echo "Retrying..." && timeout /t 3 /nobreak >nul && docker compose exec db pg_isready -U trazawork -d trazawork)
+	@docker compose exec db pg_isready -U tookly -d tookly --timeout=30 || (echo "Retrying..." && timeout /t 3 /nobreak >nul && docker compose exec db pg_isready -U tookly -d tookly)
 	@echo "Database ready at localhost:5432"
 
 db-down: ## Stop PostgreSQL database
@@ -23,7 +23,7 @@ db-logs: ## Show database logs
 	docker compose logs -f db
 
 db-shell: ## Open psql shell
-	docker exec -it trazawork-db psql -U trazawork -d trazawork
+	docker exec -it tookly-db psql -U tookly -d tookly
 
 db-reset: db-down ## Reset database (destroy all data)
 	rm -rf .docker/postgres

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Traza Work
+# Tookly
 
-Traza Work is a source-available workflow platform for teams. Capture ideas, plan work, track execution, and follow through — regardless of your industry or methodology.
+Tookly is a source-available workflow platform for teams. Capture ideas, plan work, track execution, and follow through — regardless of your industry or methodology.
 
 Software delivery is the first deeply defined workflow: documentation, decisions, and architecture feed the backlog, roadmap, and sprints. The long-term goal is broader: any team, any domain.
 
@@ -11,9 +11,9 @@ Software delivery is the first deeply defined workflow: documentation, decisions
 - Self-hostable — no vendor lock-in, no paywalled core features.
 - Simple to start, flexible to grow — works for a two-person team and scales to an organization.
 
-## Why Traza Work
+## Why Tookly
 
-| | Traza Work | Jira + Confluence |
+| | Tookly | Jira + Confluence |
 |---|---|---|
 | Self-hosted | Yes | Paid / complex |
 | Docs and planning together | Yes (target) | Split products |
@@ -21,7 +21,7 @@ Software delivery is the first deeply defined workflow: documentation, decisions
 | Cross-industry templates | Planned | Available but expensive |
 | Source-available | Yes (BSL 1.1) | No |
 
-Jira is a useful reference for software workflows. Traza Work is not a clone — it is a workflow platform with its own identity.
+Jira is a useful reference for software workflows. Tookly is not a clone — it is a workflow platform with its own identity.
 
 ## Current product baseline
 
@@ -58,8 +58,8 @@ Summary:
 ## Getting started
 
 ```bash
-git clone https://github.com/start-codex/trazawork
-cd trazawork
+git clone https://github.com/start-codex/tookly
+cd tookly
 docker compose up --build
 ```
 
@@ -117,4 +117,4 @@ Business Source License 1.1 — see [LICENSE](LICENSE) for details.
 - **Competing SaaS**: not permitted under BSL. Contact licensing@startcodex.com for commercial licensing.
 - **Change date**: each version converts to Apache License 2.0 four years after release.
 
-Traza Work is source-available. [Traza Work Cloud](https://trazawork.com) is a commercial SaaS product maintained by Start Codex SAS.
+Tookly is source-available. [Tookly Cloud](https://tookly.com) is a commercial SaaS product maintained by Start Codex SAS.

--- a/cmd/server/api.go
+++ b/cmd/server/api.go
@@ -9,13 +9,13 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/boards"
-	"github.com/start-codex/trazawork/internal/issues"
-	"github.com/start-codex/trazawork/internal/issuetypes"
-	"github.com/start-codex/trazawork/internal/projects"
-	"github.com/start-codex/trazawork/internal/statuses"
-	"github.com/start-codex/trazawork/internal/users"
-	"github.com/start-codex/trazawork/internal/workspaces"
+	"github.com/start-codex/tookly/internal/boards"
+	"github.com/start-codex/tookly/internal/issues"
+	"github.com/start-codex/tookly/internal/issuetypes"
+	"github.com/start-codex/tookly/internal/projects"
+	"github.com/start-codex/tookly/internal/statuses"
+	"github.com/start-codex/tookly/internal/users"
+	"github.com/start-codex/tookly/internal/workspaces"
 )
 
 // newAPIHandler builds the API sub-mux with auth middleware and all domain routes.

--- a/cmd/server/authz_routes_test.go
+++ b/cmd/server/authz_routes_test.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/sessions"
-	"github.com/start-codex/trazawork/internal/testpg"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/sessions"
+	"github.com/start-codex/tookly/internal/testpg"
 )
 
 // setupTestServer creates a test HTTP server with the full API handler stack.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/migrations"
+	"github.com/start-codex/tookly/migrations"
 )
 
 func main() {

--- a/cmd/server/middleware.go
+++ b/cmd/server/middleware.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/respond"
-	"github.com/start-codex/trazawork/internal/sessions"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/respond"
+	"github.com/start-codex/tookly/internal/sessions"
 )
 
 type statusWriter struct {

--- a/cmd/server/static.go
+++ b/cmd/server/static.go
@@ -9,7 +9,7 @@ import (
 	"io/fs"
 	"net/http"
 
-	"github.com/start-codex/trazawork/ui"
+	"github.com/start-codex/tookly/ui"
 )
 
 // registerUI mounts the embedded SPA under "/". API routes registered before

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,28 @@
 services:
   db:
     image: postgres:18-alpine
-    container_name: trazawork-db
+    container_name: tookly-db
     environment:
-      POSTGRES_USER: ${DB_USER:-trazawork}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-trazawork}
-      POSTGRES_DB: ${DB_NAME:-trazawork}
+      POSTGRES_USER: ${DB_USER:-tookly}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-tookly}
+      POSTGRES_DB: ${DB_NAME:-tookly}
     ports:
       - "${DB_PORT:-5432}:5432"
     volumes:
       - ./.docker/postgres:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-trazawork} -d ${DB_NAME:-trazawork}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-tookly} -d ${DB_NAME:-tookly}"]
       interval: 5s
       timeout: 5s
       retries: 5
 
   app:
     build: .
-    container_name: trazawork-app
+    container_name: tookly-app
     ports:
       - "${APP_PORT:-8080}:8080"
     environment:
-      DATABASE_URL: postgres://${DB_USER:-trazawork}:${DB_PASSWORD:-trazawork}@db:5432/${DB_NAME:-trazawork}?sslmode=disable
+      DATABASE_URL: postgres://${DB_USER:-tookly}:${DB_PASSWORD:-tookly}@db:5432/${DB_NAME:-tookly}?sslmode=disable
       PORT: 8080
     depends_on:
       db:

--- a/docs/01-product-scope.md
+++ b/docs/01-product-scope.md
@@ -11,7 +11,7 @@ Current project management tools tend to be:
 
 ## Vision
 
-Traza Work is a self-hostable, open-source workflow platform where any team can manage ideas, projects, and work using methodologies that fit their area.
+Tookly is a self-hostable, open-source workflow platform where any team can manage ideas, projects, and work using methodologies that fit their area.
 
 Software delivery is the first fully modeled workflow. The long-term goal is broader: a dental clinic, a law firm, a marketing agency, or an engineering team should all be able to track what needs to happen, what is happening, and what is done — without paying for enterprise plans or stitching together two separate tools.
 
@@ -25,9 +25,9 @@ workspace → project → work items
 
 Issues (the current implementation term) belong to the project, not to the board. A board is a view and configuration layer — it defines how work is visualized and in what order columns appear. The same work item can appear on multiple boards if needed.
 
-The broader target-vision term is **work item**. As Traza Work grows to support cross-industry templates, "issue" will remain valid for software contexts while "work item" covers the general case.
+The broader target-vision term is **work item**. As Tookly grows to support cross-industry templates, "issue" will remain valid for software contexts while "work item" covers the general case.
 
-## What makes Traza Work different
+## What makes Tookly different
 
 - **Documentation as the source of planning** — not a passive wiki attached as an afterthought, but the starting point for backlog creation, roadmap definition, sprint scope, and review artifacts.
 - **No Jira/Confluence split** — project pages, decision records, and execution artifacts live in the same project, not in separate products.
@@ -86,7 +86,7 @@ In software teams, the biggest gap is not the task board — it is the broken co
 
 Decisions get made in meetings and disappear. Business rules live in someone's head. Architecture choices are buried in old pull requests. Sprint planning happens without context.
 
-Traza Work's target vision for software: **documentation is the source of planning**, not a passive wiki.
+Tookly's target vision for software: **documentation is the source of planning**, not a passive wiki.
 
 Teams document:
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Traza Work is a workflow platform. Software delivery is the first deeply defined methodology. Broader cross-industry adoption comes through templates and methodology-aware configuration. Documentation-led planning is a major differentiator.
+Tookly is a workflow platform. Software delivery is the first deeply defined methodology. Broader cross-industry adoption comes through templates and methodology-aware configuration. Documentation-led planning is a major differentiator.
 
 Each phase has a status label:
 - `[shipped]` — exists in the codebase today.
@@ -61,7 +61,7 @@ Close the gap between what the backend supports and what the UI delivers. Delive
 
 ## Phase 2 — Software workflow depth `[planned]`
 
-Software delivery is the first deeply modeled workflow in Traza Work. This phase brings sprint-based and hierarchy-based planning.
+Software delivery is the first deeply modeled workflow in Tookly. This phase brings sprint-based and hierarchy-based planning.
 
 Note: software is the first vertical, not the only one.
 
@@ -78,7 +78,7 @@ Note: software is the first vertical, not the only one.
 
 Documentation is the **source of planning context**, not a passive wiki attached as an afterthought.
 
-This phase establishes the core differentiator of Traza Work: teams document their decisions, rules, and architecture, and from that documentation they **plan and refine** their backlog, roadmap, sprint scope, estimations, and reviews.
+This phase establishes the core differentiator of Tookly: teams document their decisions, rules, and architecture, and from that documentation they **plan and refine** their backlog, roadmap, sprint scope, estimations, and reviews.
 
 The initial implementation is **manual first**: links between documentation and work items are created explicitly by users. No automated generation.
 

--- a/front/src/routes/(app)/[workspace]/+layout.svelte
+++ b/front/src/routes/(app)/[workspace]/+layout.svelte
@@ -58,7 +58,7 @@
 				<Breadcrumb.Root>
 					<Breadcrumb.List>
 						<Breadcrumb.Item class="hidden md:block">
-							<Breadcrumb.Link href="/{data.workspace.slug}">Traza Work</Breadcrumb.Link>
+							<Breadcrumb.Link href="/{data.workspace.slug}">Tookly</Breadcrumb.Link>
 						</Breadcrumb.Item>
 						<Breadcrumb.Separator class="hidden md:block" />
 						{#each crumbs as crumb, i}

--- a/front/src/routes/login/+page.svelte
+++ b/front/src/routes/login/+page.svelte
@@ -14,7 +14,7 @@
 					<rect width="8" height="8" x="2" y="14" rx="2" /><rect width="8" height="8" x="14" y="14" rx="2" />
 				</svg>
 			</div>
-			Traza Work
+			Tookly
 		</a>
 		<LoginForm />
 	</div>

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/start-codex/trazawork
+module github.com/start-codex/tookly
 
 go 1.26
 

--- a/internal/authz/store_integration_test.go
+++ b/internal/authz/store_integration_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/internal/testpg"
+	"github.com/start-codex/tookly/internal/testpg"
 )
 
 func seedMember(t *testing.T, db *sqlx.DB, workspaceID, userID, role string) {

--- a/internal/boards/handler.go
+++ b/internal/boards/handler.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/respond"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/respond"
 )
 
 func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {

--- a/internal/boards/store.go
+++ b/internal/boards/store.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/pgutil"
+	"github.com/start-codex/tookly/internal/pgutil"
 )
 
 const boardCols = `id, project_id, name, type, filter_query, created_at, updated_at, archived_at`

--- a/internal/boards/store_integration_test.go
+++ b/internal/boards/store_integration_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/internal/testpg"
+	"github.com/start-codex/tookly/internal/testpg"
 )
 
 func TestCreateBoard(t *testing.T) {

--- a/internal/issues/handler.go
+++ b/internal/issues/handler.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/respond"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/respond"
 )
 
 func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {

--- a/internal/issues/store.go
+++ b/internal/issues/store.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/pgutil"
+	"github.com/start-codex/tookly/internal/pgutil"
 )
 
 const reorderOffset = 1000000

--- a/internal/issues/store_integration_test.go
+++ b/internal/issues/store_integration_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/internal/testpg"
+	"github.com/start-codex/tookly/internal/testpg"
 )
 
 func TestMoveIssue(t *testing.T) {

--- a/internal/issuetypes/handler.go
+++ b/internal/issuetypes/handler.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/respond"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/respond"
 )
 
 func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {

--- a/internal/issuetypes/store.go
+++ b/internal/issuetypes/store.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/pgutil"
+	"github.com/start-codex/tookly/internal/pgutil"
 )
 
 const issueTypeCols = `id, project_id, name, icon, level, created_at, updated_at, archived_at`

--- a/internal/projects/handler.go
+++ b/internal/projects/handler.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/respond"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/respond"
 )
 
 func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {

--- a/internal/projects/store.go
+++ b/internal/projects/store.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/pgutil"
+	"github.com/start-codex/tookly/internal/pgutil"
 )
 
 const selectCols = `id, workspace_id, name, key, description, created_at, updated_at, archived_at`

--- a/internal/projects/store_integration_test.go
+++ b/internal/projects/store_integration_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/internal/testpg"
+	"github.com/start-codex/tookly/internal/testpg"
 )
 
 func TestCreateProject(t *testing.T) {

--- a/internal/sessions/store_integration_test.go
+++ b/internal/sessions/store_integration_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/internal/testpg"
+	"github.com/start-codex/tookly/internal/testpg"
 )
 
 func TestCreateSession(t *testing.T) {

--- a/internal/statuses/handler.go
+++ b/internal/statuses/handler.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/respond"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/respond"
 )
 
 func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {

--- a/internal/statuses/store.go
+++ b/internal/statuses/store.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/pgutil"
+	"github.com/start-codex/tookly/internal/pgutil"
 )
 
 const statusCols = `id, project_id, name, category, position, created_at, updated_at, archived_at`

--- a/internal/testpg/testpg.go
+++ b/internal/testpg/testpg.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/migrations"
+	"github.com/start-codex/tookly/migrations"
 )
 
 const testDSNEnv = "MINI_JIRA_TEST_DSN"

--- a/internal/users/handler.go
+++ b/internal/users/handler.go
@@ -11,9 +11,9 @@ import (
 	"os"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/respond"
-	"github.com/start-codex/trazawork/internal/sessions"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/respond"
+	"github.com/start-codex/tookly/internal/sessions"
 )
 
 func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {

--- a/internal/users/store.go
+++ b/internal/users/store.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/pgutil"
+	"github.com/start-codex/tookly/internal/pgutil"
 )
 
 const userCols = `id, email, name, created_at, updated_at, archived_at`

--- a/internal/users/store_integration_test.go
+++ b/internal/users/store_integration_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/internal/testpg"
+	"github.com/start-codex/tookly/internal/testpg"
 )
 
 func TestCreateUser(t *testing.T) {

--- a/internal/workspaces/handler.go
+++ b/internal/workspaces/handler.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/authz"
-	"github.com/start-codex/trazawork/internal/respond"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/respond"
 )
 
 func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {

--- a/internal/workspaces/store.go
+++ b/internal/workspaces/store.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/start-codex/trazawork/internal/pgutil"
+	"github.com/start-codex/tookly/internal/pgutil"
 )
 
 const selectCols = `id, name, slug, created_at, updated_at, archived_at`

--- a/internal/workspaces/store_integration_test.go
+++ b/internal/workspaces/store_integration_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/start-codex/trazawork/internal/testpg"
+	"github.com/start-codex/tookly/internal/testpg"
 )
 
 func TestCreateWorkspace(t *testing.T) {


### PR DESCRIPTION
## Summary
- Rename project from Traza Work to **Tookly**
- Change Go module to `github.com/start-codex/tookly`
- Update all imports, docs, license, config, and frontend references

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./internal/...`
- [x] `go test -count=1 ./cmd/server/...`
- [x] `pnpm --dir front check`
- [x] Zero references to old names (Taskcore, Traza Work, trazawork)