### PR TITLE
docs: remove competitor-specific references, add broader comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Software delivery is the first deeply defined workflow: documentation, decisions
 
 ## Why Tookly
 
-| | Tookly | Jira + Confluence |
-|---|---|---|
-| Self-hosted | Yes | Paid / complex |
-| Docs and planning together | Yes (target) | Split products |
-| Core workflow features | All open | Many behind paywall |
-| Cross-industry templates | Planned | Available but expensive |
-| Source-available | Yes (BSL 1.1) | No |
+| | Tookly | Jira | Linear | Asana | Monday |
+|---|---|---|---|---|---|
+| Self-hosted | Yes | Paid / complex | No | No | No |
+| Docs + planning together | Yes (target) | Separate (Confluence) | No | No | No |
+| Core features | All open | Many behind paywall | Free tier limited | Free tier limited | Free tier limited |
+| Cross-industry templates | Planned | Software only | Software only | General | General |
+| Source-available | Yes (BSL 1.1) | No | No | No | No |
 
-Jira is a useful reference for software workflows. Tookly is not a clone — it is a workflow platform with its own identity.
+Tookly is not a clone of any existing tool — it is a workflow platform with its own identity.
 
 ## Current product baseline
 

--- a/docs/01-product-scope.md
+++ b/docs/01-product-scope.md
@@ -7,7 +7,7 @@ Current project management tools tend to be:
 - Too complex for small teams that just need to track work.
 - Focused exclusively on software, or so generic they offer no real methodology support.
 - Expensive to adapt — core workflow features locked behind enterprise plans.
-- Split across two products: project tracking in one tool, documentation in another. Teams end up with decisions in Confluence and work in Jira, but the two never truly talk to each other.
+- Split across two products: project tracking in one tool, documentation in another. Teams end up with decisions in one place and work in another, but the two never truly talk to each other.
 
 ## Vision
 
@@ -30,7 +30,7 @@ The broader target-vision term is **work item**. As Tookly grows to support cros
 ## What makes Tookly different
 
 - **Documentation as the source of planning** — not a passive wiki attached as an afterthought, but the starting point for backlog creation, roadmap definition, sprint scope, and review artifacts.
-- **No Jira/Confluence split** — project pages, decision records, and execution artifacts live in the same project, not in separate products.
+- **No split between tracking and docs** — project pages, decision records, and execution artifacts live in the same project, not in separate products.
 - **Templates for any industry** — workflow presets for engineering, HR, legal, marketing, finance, design, and more.
 - **No paywalled core features** — the workflows that matter are available to everyone.
 - **Self-hosted and open source** — run it on your own infrastructure, contribute to it, or fork it.

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -35,7 +35,7 @@ The frontend is compiled and embedded into the Go binary at build time. The Go s
 
 - Modular monolith (no microservices in MVP).
 - API REST mounted under `/api` (no version prefix in current routes).
-- Jira-like model: issue is owned by project and status; board is a view (filter + columns) over issues.
+- Issue belongs to a project and has a status; boards are views (filter + columns) over issues.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace Jira/Confluence-only comparison with multi-tool table (Jira, Linear, Asana, Monday)
- Remove brand names from internal docs (product-scope, architecture)
- Keep competitor names only in README comparison table

## Test plan
- [x] No competitor references in internal docs
- [x] README comparison table includes full market landscape