### PR TITLE
docs: sync all documentation with shipped state, add Phase 1.5 and Phase 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [docs/05-roadmap.md](docs/05-roadmap.md) for the full phased roadmap.
 
 Summary:
 - **Phase 0 — Foundation** `[shipped]` — core backend, domains, templates, i18n.
-- **Phase 1 — MVP hardening** `[shipped]` — full auth, membership enforcement, board UI, issue detail.
+- **Phase 1 — MVP hardening** `[in progress]` — full auth, membership enforcement, board UI, issue detail.
 - **Phase 1.5 — Identity, onboarding, and instance admin** `[planned]` — SMTP, password reset, invitations, SSO/OIDC, first-install bootstrap.
 - **Phase 2 — Software workflow depth** `[planned]` — issue hierarchy, sprints, backlog, planning board.
 - **Phase 3 — Documentation-led planning** `[planned]` — project pages, decision records, doc↔work item links.

--- a/docs/01-product-scope.md
+++ b/docs/01-product-scope.md
@@ -121,7 +121,7 @@ This relationship is **manual first**: documentation and execution artifacts are
 - Board column order is defined in the board configuration.
 - In the MVP, transitions between any two statuses are allowed (no restricted transition rules yet).
 - Issue types and statuses are per-project. An issue's type and status must belong to the same project as the issue.
-- Issue hierarchy: `parent_issue_id` exists in the schema; full hierarchy enforcement and UI are planned (Phase 2).
+- Issue hierarchy: `parent_issue_id` and `issue_type.level` exist in the schema with basic DB integrity (same-project, level ordering, anti-cycle); domain-level API validation and hierarchy UI are planned (Phase 2).
 - Issue numbering is sequential per project, generated via `project_issue_counters` to avoid race conditions.
 
 ---

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -45,9 +45,23 @@ The frontend is compiled and embedded into the Go binary at build time. The Go s
 cmd/
   server/
     main.go           # entrypoint: configures DB, router, starts server
-    middleware.go     # withRequestID, withLogger, withRecover (private to cmd)
+    api.go            # newAPIHandler: assembles API sub-mux with all domain routes
+    middleware.go     # withRequestID, withLogger, withRecover, withAuth
+    static.go         # registerUI: serves embedded frontend assets
 
 internal/
+  authz/
+    authz.go          # context helpers, RequireWorkspaceMembership, RequireWorkspaceAdmin
+    store.go          # private SQL: membership checks, role queries
+    authz_test.go
+    store_integration_test.go
+
+  sessions/
+    sessions.go       # Create, Validate, Delete; SHA-256 token hashing
+    store.go          # private SQL persistence
+    sessions_test.go
+    store_integration_test.go
+
   boards/
     boards.go         # types, errors, public API
     handler.go        # HTTP handlers + RegisterRoutes
@@ -83,7 +97,7 @@ internal/
     users.go
     handler.go
     store.go
-    password.go
+    password.go       # Argon2id password hashing
     users_test.go
     store_integration_test.go
 
@@ -96,11 +110,20 @@ internal/
 
   respond/
     respond.go        # shared HTTP utilities (respond.JSON, respond.Error, respond.Decode)
-                      # does not import any domain package
+
+  pgutil/
+    pgutil.go         # shared PostgreSQL helpers
+
+  testpg/
+    testpg.go         # test helpers: Open, EnsureMigrated, SeedUser, SeedWorkspace, SeedProject
 
 migrations/
   *.up.sql
   *.down.sql
+  migrate.go          # embedded migrations, Up() function
+
+ui/
+  ui.go               # embedded frontend dist
 
 front/
   src/
@@ -114,7 +137,7 @@ front/
 
 Handlers are thin by design: parse the request, call the domain function, write the response.
 
-Each domain package exposes a single `RegisterRoutes(mux *http.ServeMux, db *sqlx.DB)` function. `cmd/server/main.go` calls them in order. All handler functions are private (`handleCreate`, not `HandleCreate`).
+Each domain package exposes a single `RegisterRoutes(mux *http.ServeMux, db *sqlx.DB)` function. `cmd/server/api.go` calls them in order. All handler functions are private (`handleCreate`, not `HandleCreate`).
 
 Domain packages register paths **without** the `/api/` prefix. `cmd/server/main.go` mounts them on a sub-mux with `http.StripPrefix("/api", api)`, so the full public URL becomes `/api/projects/...`.
 
@@ -147,21 +170,33 @@ Each `handler.go` defines a local `fail(w, err)` function that maps domain senti
 
 ---
 
-## Authentication
+## Authentication and authorization
 
 ### Current state
 
-- `POST /api/auth/login` exists and returns a user payload on success.
-- The frontend currently stores the returned user object in **local storage**.
-- Session storage layer shipped: `internal/sessions` with `Create`, `Validate`, `Delete`. Tokens are SHA-256 hashed before storage; archived users are rejected on validation.
-- Cookie-based session middleware, auth endpoints (`/auth/me`, `/auth/logout`), and per-handler membership enforcement are **not yet implemented** (PRs 2–6 of Phase 1).
+- Server-side sessions with secure cookies: `HttpOnly`, `Secure` (conditional), `SameSite=Strict`, 7-day TTL.
+- Session tokens are SHA-256 hashed before database storage; raw tokens never persisted.
+- `POST /api/auth/login` — authenticates credentials, creates session, sets `session_id` cookie.
+- `GET /api/auth/me` — always returns 200; `{ authenticated: true, user }` or `{ authenticated: false }`.
+- `POST /api/auth/logout` — idempotent, deletes session, clears cookie, returns 204.
+- `withAuth` middleware wraps the `/api` sub-mux. Allowlisted routes: `POST /users`, `POST /auth/login`, `GET /auth/me`, `POST /auth/logout`.
+- `internal/authz` provides context helpers (`WithUserID`, `UserIDFromContext`) and authorization functions:
+  - `RequireWorkspaceMembership` — verifies user is a workspace member.
+  - `RequireWorkspaceAdmin` — verifies user has `admin` or `owner` role.
+  - `RequireProjectMembership` — resolves project → workspace, then checks membership.
+  - `RequireBoardAccess` — resolves board → project → workspace, then checks membership.
+  - `RequireColumnAccess` — resolves column → board → project → workspace, then checks membership.
+- Identity derived from session context — no client-controlled `owner_id`, `reporter_id`, or `user_id` in API contracts.
+- Workspace admin/owner role required for administrative routes (archive workspace, manage members, create projects, configure workflow).
+- Frontend auth uses in-memory store with `/auth/me` validation on page load; no `localStorage` for auth state.
 
-### Target
+### Planned (Phase 1.5)
 
-- Server-side sessions with secure cookies: `HttpOnly`, `Secure`, `SameSite=Strict`.
-- Session middleware validates the cookie on every request and injects the authenticated user into the context.
-- Workspace and project membership enforced per handler using the context user.
-- Logout endpoint invalidates the server-side session.
+- Transactional email: SMTP configuration, email templates, delivery pipeline.
+- Password reset and change-password flows with expiring tokens.
+- User invitations: invite by email, pending invite lifecycle, role assignment on acceptance.
+- Federated identity: OpenID Connect (OIDC), external identity providers, JIT provisioning.
+- Instance bootstrap: first-install flow, global administrator creation, system-wide configuration.
 
 ---
 
@@ -181,8 +216,9 @@ Each `handler.go` defines a local `fail(w, err)` function that maps domain senti
 
 ## Observability
 
-- Structured JSON logs.
+- Structured JSON logs via `log/slog`.
 - Request ID per request (middleware in `cmd/server/middleware.go`).
+- Static asset paths (`/_app/`) excluded from request logging to reduce noise.
 - Minimal metrics target: latency, error rate, throughput.
 
 ---
@@ -190,9 +226,11 @@ Each `handler.go` defines a local `fail(w, err)` function that maps domain senti
 ## Security
 
 - Input validation in the handler (before calling the domain function) and again inside the domain (`Validate()` as second line of defense).
-- CSRF protection for state-changing endpoints — planned as part of full session-based authentication.
-- Cookies with `HttpOnly`, `Secure`, `SameSite` — planned, pending auth completion.
-- Access control per workspace and project — planned, pending auth completion.
+- Server-side sessions with `HttpOnly`, `Secure`, `SameSite=Strict` cookies.
+- Workspace and project membership enforced per handler using context user.
+- Admin/owner role enforcement on all administrative and workflow configuration routes.
+- CSRF protection for state-changing endpoints — planned.
+- Password hashing: Argon2id (memory=64MB, iterations=3, parallelism=4, salt=16B, key=32B).
 
 ---
 
@@ -204,17 +242,29 @@ In the documentation-led planning phase (Phase 3), the architecture extends to s
 - Pages and work items share explicit link records — no implicit coupling.
 - Planning workflows (backlog refinement, sprint planning, reviews) reference documented context directly.
 - The initial implementation is **user-driven and manual**: users create links, not the system.
-- Automated inference from documentation is deferred to Phase 5 or later.
 
 This means no separate "wiki service" or external documentation product. Documentation is a first-class domain in the same monolith.
 
 ---
 
+## Future architecture — AI assistant and MCP
+
+In Phase 6, the architecture extends to support a workflow-oriented AI assistant. See [docs/06-ai-assistant.md](06-ai-assistant.md) for full details.
+
+- The assistant runs within the same monolith, not as a separate service.
+- AI provider is configurable per workspace or instance (OpenAI, Anthropic, Google, Ollama, or any compatible API).
+- The assistant executes operations under the authenticated user's session and permissions — no AI superuser.
+- MCP (Model Context Protocol) provides a connector layer for reading and acting on external systems.
+- Without a configured provider, AI features are unavailable but Tookly works normally.
+
+---
+
 ## Planned additions
 
-- Session middleware and server-side session store.
-- Workspace and project membership enforcement in all handlers.
 - Sprint and backlog endpoints (`internal/sprints/`).
 - Project templates API (extend `internal/projects/` or add `internal/templates/`).
 - Notification domain (`internal/notifications/`).
 - Project documentation pages domain (`internal/pages/`).
+- AI assistant domain and MCP connector layer.
+- Transactional email pipeline.
+- Instance configuration and administration.

--- a/docs/03-data-model.md
+++ b/docs/03-data-model.md
@@ -12,101 +12,139 @@
 
 ### Workspace
 
-- `id`
+- `id` (UUID, PK)
 - `name`
 - `slug`
 - `created_at`
+- `updated_at`
+- `archived_at` (nullable)
 
 ### User
 
-- `id`
-- `email`
+- `id` (UUID, PK)
+- `email` (unique)
 - `name`
-- `password_hash`
+- `password_hash` (Argon2id)
 - `created_at`
+- `updated_at`
+- `archived_at` (nullable)
 
 ### WorkspaceMember
 
-- `workspace_id`
-- `user_id`
+- `workspace_id` (FK)
+- `user_id` (FK)
 - `role` (`owner`, `admin`, `member`)
+- `created_at`
+- `updated_at`
+- `archived_at` (nullable)
+
+### Session
+
+- `id` (TEXT, PK — SHA-256 hash of the raw token)
+- `user_id` (FK → User)
+- `created_at`
+- `expires_at`
+- `last_used_at` (nullable — set on creation, not refreshed per request in current implementation)
+
+Indexes: `user_id`, `expires_at`.
 
 ### Project
 
-- `id`
-- `workspace_id`
+- `id` (UUID, PK)
+- `workspace_id` (FK)
 - `name`
 - `key` (e.g. `ENG`, `MKT`) — short uppercase identifier used in issue keys
 - `description`
 - `created_at`
+- `updated_at`
+- `archived_at` (nullable)
 
 ### ProjectMember
 
-- `project_id`
-- `user_id`
+- `project_id` (FK)
+- `user_id` (FK)
 - `role` (`admin`, `member`, `viewer`)
+- `created_at`
+- `updated_at`
+- `archived_at` (nullable)
+
+Note: `project_members` exists in the schema and is populated during project member management, but is not currently used as an authorization source. Authorization is based on `workspace_members` only (Phase 1).
 
 ### ProjectIssueCounter
 
 - `project_id` (PK)
 - `last_number`
+- `created_at`
 - `updated_at`
 
 Used to generate sequential issue numbers per project without race conditions. See implementation note below.
 
 ### Status
 
-- `id`
-- `project_id`
+- `id` (UUID, PK)
+- `project_id` (FK)
 - `name` (e.g. `To Do`, `In Progress`, `Done`)
 - `category` (`todo`, `doing`, `done`)
 - `position`
+- `created_at`
+- `updated_at`
+- `archived_at` (nullable)
 
 **Note:** when a project is created with a Kanban or Scrum template, statuses are preconfigured automatically. Board column mapping is **not auto-created** by the template.
 
 ### IssueType
 
-- `id`
-- `project_id`
+- `id` (UUID, PK)
+- `project_id` (FK)
 - `name` (e.g. `Epic`, `Story`, `Task`, `Subtask`, `Bug`)
 - `icon`
 - `level` (hierarchy depth: 0 = top-level, higher = deeper child)
+- `created_at`
+- `updated_at`
+- `archived_at` (nullable)
 
 ### Board
 
-- `id`
-- `project_id`
+- `id` (UUID, PK)
+- `project_id` (FK)
 - `name`
 - `type` (`kanban`, `scrum`)
 - `filter_query` (board-level issue filter)
+- `created_at`
+- `updated_at`
+- `archived_at` (nullable)
 
 ### BoardColumn
 
-- `id`
-- `board_id`
+- `id` (UUID, PK)
+- `board_id` (FK)
 - `name`
 - `position`
+- `created_at`
+- `updated_at`
+- `archived_at` (nullable)
 
 ### BoardColumnStatus
 
-- `board_column_id`
-- `status_id`
+- `board_column_id` (FK)
+- `status_id` (FK)
+- `created_at`
 
 A column can map to one or more statuses. Both the column and the status must belong to the same project.
 
 ### Issue
 
-- `id`
-- `project_id`
+- `id` (UUID, PK)
+- `project_id` (FK)
 - `number` (sequential per project)
-- `issue_type_id`
-- `status_id`
-- `parent_issue_id` (nullable) — hierarchy field; full enforcement and UI are planned (Phase 2)
+- `issue_type_id` (FK)
+- `status_id` (FK)
+- `parent_issue_id` (nullable, FK → Issue) — hierarchy field
 - `title`
 - `description`
 - `priority` (`low`, `medium`, `high`, `critical`)
-- `assignee_id` (nullable)
-- `reporter_id`
+- `assignee_id` (nullable, FK → User)
+- `reporter_id` (FK → User)
 - `due_date` (nullable)
 - `status_position` — sort order within a status column
 - `created_at`
@@ -115,20 +153,22 @@ A column can map to one or more statuses. Both the column and the status must be
 
 Recommended public key in UI/API: `PROJECT_KEY-NUMBER` (e.g. `ENG-123`).
 
-**Note:** `parent_issue_id` and `issue_type.level` exist in the schema today. Full hierarchy domain rules (cycle prevention, level validation) and the corresponding UI are planned in Phase 2.
-
 ### IssueEvent (audit log)
 
-- `id`
-- `issue_id`
-- `actor_id`
+- `id` (UUID, PK)
+- `issue_id` (FK)
+- `actor_id` (FK → User)
 - `event_type` (`created`, `updated`, `moved`, `commented`)
 - `payload_json`
 - `created_at`
 
+Note: the `issue_events` table exists in the schema but does not have domain functions or API endpoints yet. It is reserved for future audit trail and activity feed features.
+
 ---
 
 ## Integrity rules
+
+These constraints are enforced at the database level:
 
 - `Issue.issue_type_id` must belong to the same `project_id` as the issue.
 - `Issue.status_id` must belong to the same `project_id` as the issue.
@@ -137,6 +177,8 @@ Recommended public key in UI/API: `PROJECT_KEY-NUMBER` (e.g. `ENG-123`).
 - Anti-cycle: `parent_issue_id` chains must not form cycles.
 - `BoardColumnStatus`: column and status must belong to the same project.
 - `status_position` is unique per (`project_id`, `status_id`) for active issues (`archived_at IS NULL`).
+
+Note: `parent_issue_id` and `issue_type.level` integrity rules exist in the database. Full hierarchy domain rules (cycle prevention beyond DB constraints, level validation in the API) and the corresponding UI are planned in Phase 2.
 
 ---
 
@@ -147,6 +189,8 @@ Recommended public key in UI/API: `PROJECT_KEY-NUMBER` (e.g. `ENG-123`).
 - `Issue(parent_issue_id)`
 - `Status(project_id, position)`
 - `BoardColumn(board_id, position)`
+- `Session(user_id)`
+- `Session(expires_at)`
 
 ---
 
@@ -170,13 +214,32 @@ The returned `last_number` is used as `issues.number` in the same transaction.
 
 ## Future model directions
 
-These entities are planned for future phases. Field-level design is intentionally deferred until implementation planning begins.
+These entities and capabilities are planned for future phases. Field-level design is intentionally deferred until implementation planning begins.
 
+**Phase 1.5 — Identity, onboarding, and instance admin**
+- Invitation records: pending invites with expiration, role assignment, and acceptance lifecycle.
+- Password reset / recovery tokens: expiring tokens for account recovery flows.
+- SMTP configuration: instance-level settings for transactional email delivery.
+- Federated identity: OIDC provider configuration, account linking, JIT provisioning metadata.
+- Instance configuration: global admin records, system-wide settings, bootstrap state.
+
+**Phase 2 — Software workflow depth**
 - **Sprint / SprintIssue** — sprint planning and execution; links issues to time-boxed iterations.
 - **Comment** — threaded comments on issues.
 - **Attachment** — files attached to issues.
 - **CustomField** — per-project extensible fields on issues.
-- **ProjectTemplate** — reusable workflow preset that bundles statuses, issue types, board layout, and optionally a documentation structure.
-- **Notification** — event-driven alerts for status changes, assignments, mentions.
-- **ProjectPage / WikiPage** — documentation pages that belong to a project; support for Markdown content, page hierarchy (parent/child), and decision records.
+
+**Phase 3 — Documentation-led planning**
+- **ProjectPage** — documentation pages that belong to a project; Markdown content, page hierarchy (parent/child), and decision records.
 - **Page–WorkItem link** — an explicit link record between a documentation page and a work item, enabling manual traceability between documented decisions and execution artifacts.
+
+**Phase 4 — Cross-industry templates**
+- **ProjectTemplate** — reusable workflow preset that bundles statuses, issue types, board layout, and optionally a documentation structure.
+
+**Phase 5 — Automation + reporting**
+- **Notification** — event-driven alerts for status changes, assignments, mentions.
+
+**Phase 6 — AI assistant and MCP**
+- Provider configuration records: endpoint, API key, model, scoped per workspace or instance.
+- Proposal records: suggested changes from AI or human origin, with target entity and payload.
+- Assistant interaction metadata for context and history.

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -36,11 +36,10 @@ The core platform infrastructure and first working end-to-end flow.
 
 **What is not yet shipped in this phase**
 - UI drag-and-drop: `MoveIssue` backend is ready; the frontend is not wired yet.
-- Full cookie-based auth: `POST /api/auth/login` exists; session management and per-handler enforcement are pending.
 
 ---
 
-## Phase 1 — MVP hardening `[shipped]`
+## Phase 1 — MVP hardening `[in progress]`
 
 Close the gap between what the backend supports and what the UI delivers. Deliver a fully usable, secure baseline.
 
@@ -96,7 +95,7 @@ Software delivery is the first deeply modeled workflow in Tookly. This phase bri
 
 Note: software is the first vertical, not the only one.
 
-- **Issue hierarchy**: Epic → Story → Task → Subtask. Schema fields (`parent_issue_id`, `issue_type.level`) already exist; domain rules (cycle prevention, level validation) and UI are pending.
+- **Issue hierarchy**: Epic → Story → Task → Subtask. Schema fields (`parent_issue_id`, `issue_type.level`) and basic DB integrity (same-project, level ordering, anti-cycle) already exist; domain-level validation in the API and the hierarchy UI are pending.
 - **Backlog view**: list of issues not assigned to any sprint; drag issues into a sprint.
 - **Sprint model**: create sprint, add issues from backlog, start sprint, close sprint.
 - **Sprint planning board**: board scoped to a single active sprint.


### PR DESCRIPTION
## Summary
- Sync `02-architecture.md` and `03-data-model.md` with shipped auth/authz state
- Add Session entity, complete missing timestamps across all entities
- Clarify workspace-based auth model and ProjectMember status
- Add Phase 1.5 (identity, onboarding, instance admin) to roadmap and product scope
- Add Phase 6 (AI assistant and MCP) to roadmap with `docs/06-ai-assistant.md`
- Fix Phase 1 status: `[in progress]` (auth shipped, board UI/filters pending)
- Remove obsolete "pending" references for auth/cookies/authz
- Clarify issue hierarchy: DB integrity exists, domain API/UI pending

## Files changed
- `docs/01-product-scope.md`
- `docs/02-architecture.md`
- `docs/03-data-model.md`
- `docs/05-roadmap.md`
- `docs/06-ai-assistant.md` (new)
- `README.md`