### PR TITLE
[codex] Add Tookly logo and README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
+<p align="center">
+  <img src="front/src/lib/assets/tookly-logo.svg" alt="Tookly logo" width="180" />
+</p>
+
 # Tookly
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white" alt="Go 1.26" />
+  <img src="https://img.shields.io/badge/SvelteKit-2-FF3E00?logo=svelte&logoColor=white" alt="SvelteKit 2" />
+  <img src="https://img.shields.io/badge/PostgreSQL-16-4169E1?logo=postgresql&logoColor=white" alt="PostgreSQL 16" />
+  <img src="https://img.shields.io/badge/License-BSL%201.1-0F172A" alt="License BSL 1.1" />
+</p>
 
 Tookly is a source-available workflow platform for teams. Capture ideas, plan work, track execution, and follow through — regardless of your industry or methodology.
 

--- a/front/src/lib/assets/tookly-logo.svg
+++ b/front/src/lib/assets/tookly-logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" fill="none">
+  <path
+    fill="#FACC15"
+    d="M25 78C25 44 54 20 98 20C131 20 142 43 142 74C142 116 116 142 81 142C47 142 25 115 25 78Z"
+  />
+  <path
+    d="M107 47C98 59 91 68 83 78C76 86 68 93 58 89C48 85 45 72 53 64C61 56 73 60 83 78C92 94 100 105 108 116"
+    stroke="#0B1F5E"
+    stroke-width="12"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- add a new Tookly SVG logo asset
- add the logo and informative badges to the README

## Validation
- Not run (documentation and SVG asset changes only)
