### PR TITLE
feat(issues): add due_date to issue create and update API contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 - Added workspace membership enforcement on all API routes (read and write)
 - Added project-member creation guard: target user must be a workspace member
 - Added `sessions.IsAuthError` helper for centralized error classification
+- Added `due_date` field to issue create and update API contracts (`YYYY-MM-DD` or `null`)
 - Added `RequireWorkspaceAdmin` to `internal/authz` for admin/owner role enforcement
 - Added `ApiError` class to frontend API client for typed HTTP error handling
 - Added `auth.me()` and `auth.logout()` to frontend API client

--- a/cmd/server/authz_routes_test.go
+++ b/cmd/server/authz_routes_test.go
@@ -641,6 +641,92 @@ func TestAdminWiring_MemberReadNoRegression(t *testing.T) {
 	}
 }
 
+// TestDueDate_CreateAndUpdate verifies due_date can be set on create,
+// changed on update, and cleared by sending null.
+func TestDueDate_CreateAndUpdate(t *testing.T) {
+	db := testpg.Open(t)
+	testpg.EnsureMigrated(t, db)
+	srv := setupTestServer(t, db)
+
+	user := testpg.SeedUser(t, db)
+	wsID := testpg.SeedWorkspace(t, db)
+	seedMember(t, db, wsID, user, "member")
+	projID := testpg.SeedProject(t, db, wsID, "DUED")
+	token := loginCookie(t, db, user)
+
+	statusID := seedStatus(t, db, projID)
+	issueTypeID := seedIssueType(t, db, projID)
+
+	// Create issue with due_date
+	env := doRequestWithBody(t, srv, "POST", "/projects/"+projID+"/issues", token, map[string]any{
+		"issue_type_id": issueTypeID,
+		"status_id":     statusID,
+		"title":         "Issue with date",
+		"due_date":      "2026-04-15",
+	})
+	if env.Status != 201 {
+		t.Fatalf("create with due_date: status = %d, want 201 (error: %s)", env.Status, env.Error)
+	}
+	var created struct {
+		ID      string  `json:"id"`
+		DueDate *string `json:"due_date"`
+	}
+	if err := json.Unmarshal(env.Data, &created); err != nil {
+		t.Fatalf("unmarshal created issue: %v", err)
+	}
+	if created.DueDate == nil || (*created.DueDate)[:10] != "2026-04-15" {
+		t.Fatalf("created due_date = %v, want 2026-04-15", created.DueDate)
+	}
+
+	// Update due_date to a different value
+	env = doRequestWithBody(t, srv, "PUT", "/projects/"+projID+"/issues/"+created.ID, token, map[string]any{
+		"title":    "Issue with date",
+		"priority": "medium",
+		"due_date": "2026-05-01",
+	})
+	if env.Status != 200 {
+		t.Fatalf("update due_date: status = %d, want 200 (error: %s)", env.Status, env.Error)
+	}
+	var updated struct {
+		DueDate *string `json:"due_date"`
+	}
+	if err := json.Unmarshal(env.Data, &updated); err != nil {
+		t.Fatalf("unmarshal updated issue: %v", err)
+	}
+	if updated.DueDate == nil || (*updated.DueDate)[:10] != "2026-05-01" {
+		t.Fatalf("updated due_date = %v, want 2026-05-01", updated.DueDate)
+	}
+
+	// Clear due_date by sending null
+	env = doRequestWithBody(t, srv, "PUT", "/projects/"+projID+"/issues/"+created.ID, token, map[string]any{
+		"title":    "Issue with date",
+		"priority": "medium",
+		"due_date": nil,
+	})
+	if env.Status != 200 {
+		t.Fatalf("clear due_date: status = %d, want 200 (error: %s)", env.Status, env.Error)
+	}
+	var cleared struct {
+		DueDate *string `json:"due_date"`
+	}
+	if err := json.Unmarshal(env.Data, &cleared); err != nil {
+		t.Fatalf("unmarshal cleared issue: %v", err)
+	}
+	if cleared.DueDate != nil {
+		t.Fatalf("cleared due_date = %v, want nil", *cleared.DueDate)
+	}
+
+	// Create issue without due_date (should work, it's optional)
+	env = doRequestWithBody(t, srv, "POST", "/projects/"+projID+"/issues", token, map[string]any{
+		"issue_type_id": issueTypeID,
+		"status_id":     statusID,
+		"title":         "Issue no date",
+	})
+	if env.Status != 201 {
+		t.Fatalf("create without due_date: status = %d, want 201 (error: %s)", env.Status, env.Error)
+	}
+}
+
 func seedColumn(t *testing.T, db *sqlx.DB, boardID string) string {
 	t.Helper()
 	var id string

--- a/docs/01-product-scope.md
+++ b/docs/01-product-scope.md
@@ -132,6 +132,7 @@ This relationship is **manual first**: documentation and execution artifacts are
 - Sprint model: create, populate, start, and close sprints; backlog view.
 - Cross-industry workflow templates.
 - Custom fields per project.
+- Planning metadata per work item, such as start date and estimation fields.
 - Rule-based automations (e.g. notify on status change).
 - Transactional email flows for invitations, password reset, and system notifications.
 - Identity federation and instance-level administration for self-hosted deployments.

--- a/docs/03-data-model.md
+++ b/docs/03-data-model.md
@@ -225,6 +225,9 @@ These entities and capabilities are planned for future phases. Field-level desig
 
 **Phase 2 — Software workflow depth**
 - **Sprint / SprintIssue** — sprint planning and execution; links issues to time-boxed iterations.
+- **Issue.start_date** — actual work-start date for teams that track when implementation begins.
+- **Issue.story_points** — relative-effort field for sprint planning and velocity.
+- **Estimation model** — configurable team-level approach for time-, effort-, or point-based estimation; deferred until its semantics are defined.
 - **Comment** — threaded comments on issues.
 - **Attachment** — files attached to issues.
 - **CustomField** — per-project extensible fields on issues.

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -52,7 +52,7 @@ Close the gap between what the backend supports and what the UI delivers. Delive
 - PR 6 `[shipped]` — Frontend session migration (replace auth localStorage with `/auth/me`) and workflow configuration admin enforcement.
 
 **Remaining UI work** (4-PR delivery plan):
-- PR 21 `[pending]` — Add `due_date` to issue update and create API contracts.
+- PR 21 `[shipped]` — Add `due_date` to issue update and create API contracts.
 - PR 22 `[pending]` — Issue detail page: view and edit title, description, priority, assignee, due date.
 - PR 23 `[pending]` — Board drag-and-drop: move issues between columns with optimistic updates.
 - PR 24 `[pending]` — Basic board filters: client-side filtering by assignee, priority, and issue type.
@@ -100,6 +100,8 @@ Note: software is the first vertical, not the only one.
 - **Backlog view**: list of issues not assigned to any sprint; drag issues into a sprint.
 - **Sprint model**: create sprint, add issues from backlog, start sprint, close sprint.
 - **Sprint planning board**: board scoped to a single active sprint.
+- **Planning fields for software teams**: `start_date` to capture when work actually began, and `story_points` to capture relative effort for sprint planning and velocity.
+- **Estimation model**: remains configurable by team and is deferred until the platform defines how time-based and effort-based estimates coexist.
 - **Retrospective notes**: free-text notes attached to a closed sprint.
 - **Issue key display**: `ENG-42` format in UI and API responses.
 

--- a/internal/issues/handler.go
+++ b/internal/issues/handler.go
@@ -9,11 +9,23 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/start-codex/tookly/internal/authz"
 	"github.com/start-codex/tookly/internal/respond"
 )
+
+func parseDueDate(s *string) (*time.Time, error) {
+	if s == nil || *s == "" {
+		return nil, nil
+	}
+	t, err := time.Parse("2006-01-02", *s)
+	if err != nil {
+		return nil, errors.New("due_date must be YYYY-MM-DD format")
+	}
+	return &t, nil
+}
 
 func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {
 	mux.HandleFunc("POST /projects/{projectID}/issues", handleCreate(db))
@@ -55,16 +67,22 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			return
 		}
 		var body struct {
-			IssueTypeID   string `json:"issue_type_id"`
-			StatusID      string `json:"status_id"`
-			ParentIssueID string `json:"parent_issue_id"`
-			Title         string `json:"title"`
-			Description   string `json:"description"`
-			Priority      string `json:"priority"`
-			AssigneeID    string `json:"assignee_id"`
+			IssueTypeID   string  `json:"issue_type_id"`
+			StatusID      string  `json:"status_id"`
+			ParentIssueID string  `json:"parent_issue_id"`
+			Title         string  `json:"title"`
+			Description   string  `json:"description"`
+			Priority      string  `json:"priority"`
+			AssigneeID    string  `json:"assignee_id"`
+			DueDate       *string `json:"due_date"`
 		}
 		if err := respond.Decode(r, &body); err != nil {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		dueDate, err := parseDueDate(body.DueDate)
+		if err != nil {
+			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
 		params := CreateIssueParams{
@@ -77,6 +95,7 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			Priority:      body.Priority,
 			AssigneeID:    body.AssigneeID,
 			ReporterID:    authedUserID,
+			DueDate:       dueDate,
 		}
 		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
@@ -137,9 +156,15 @@ func handleUpdate(db *sqlx.DB) http.HandlerFunc {
 			Description string  `json:"description"`
 			Priority    string  `json:"priority"`
 			AssigneeID  *string `json:"assignee_id"`
+			DueDate     *string `json:"due_date"`
 		}
 		if err := respond.Decode(r, &body); err != nil {
 			respond.Error(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		dueDate, err := parseDueDate(body.DueDate)
+		if err != nil {
+			respond.Error(w, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
 		params := UpdateIssueParams{
@@ -149,6 +174,7 @@ func handleUpdate(db *sqlx.DB) http.HandlerFunc {
 			Description: body.Description,
 			Priority:    body.Priority,
 			AssigneeID:  body.AssigneeID,
+			DueDate:     dueDate,
 		}
 		if err := params.Validate(); err != nil {
 			respond.Error(w, http.StatusUnprocessableEntity, err.Error())


### PR DESCRIPTION
## Summary
- Extend `POST /projects/{id}/issues` and `PUT /projects/{id}/issues/{id}` to accept `due_date`
- Format: `YYYY-MM-DD` string or `null` to clear
- Handler parses and converts to `*time.Time`; store already supported `due_date`
- HTTP test covers: create with date, update to change, clear with null, create without date

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./internal/...`
- [x] `go test -count=1 ./cmd/server/...`