### PR TITLE
feat(ui): add board drag-and-drop with optimistic updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ front/.idea
 # Local development and planning files
 AGENTS.md
 plans/
-
+plan-cloud.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 - Added workspace membership enforcement on all API routes (read and write)
 - Added project-member creation guard: target user must be a workspace member
 - Added `sessions.IsAuthError` helper for centralized error classification
+- Added board drag-and-drop: move issues between status columns and reorder within columns via `svelte-dnd-action`
 - Added issue detail page at `/{workspace}/projects/{id}/issues/{issueID}` with edit for title, description, priority, assignee, due date
 - Added clickable issue cards on board view linking to issue detail
 - Added `due_date` field to issue create and update API contracts (`YYYY-MM-DD` or `null`)

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ What is shipped today:
 - Workspaces and projects.
 - Kanban and Scrum project templates (preconfigure statuses and one default board).
 - Boards, statuses, issue types, issues CRUD.
-- `MoveIssue` API (backend and API layer complete).
+- Board drag-and-drop: move issues between columns and reorder within columns.
+- Issue detail page: view and edit title, description, priority, assignee, due date.
 - Local email/password authentication with server-side sessions.
+- Workspace and project membership enforcement with admin/owner roles.
 - Internationalization: English and Spanish.
 
 Not in the current baseline yet: SMTP delivery, password reset, user invitations, SSO/OIDC, or a first-install global admin bootstrap flow.

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -54,7 +54,7 @@ Close the gap between what the backend supports and what the UI delivers. Delive
 **Remaining UI work** (4-PR delivery plan):
 - PR 21 `[shipped]` — Add `due_date` to issue update and create API contracts.
 - PR 22 `[shipped]` — Issue detail page: view and edit title, description, priority, assignee, due date.
-- PR 23 `[pending]` — Board drag-and-drop: move issues between columns with optimistic updates.
+- PR 23 `[shipped]` — Board drag-and-drop: move issues between columns with optimistic updates.
 - PR 24 `[pending]` — Basic board filters: client-side filtering by assignee, priority, and issue type.
 
 ---

--- a/front/package.json
+++ b/front/package.json
@@ -31,6 +31,7 @@
 		"vite": "^7.3.1"
 	},
 	"dependencies": {
-		"@inlang/paraglide-js": "^2.13.1"
+		"@inlang/paraglide-js": "^2.13.1",
+		"svelte-dnd-action": "^0.9.69"
 	}
 }

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@inlang/paraglide-js':
         specifier: ^2.13.1
         version: 2.13.1
+      svelte-dnd-action:
+        specifier: ^0.9.69
+        version: 0.9.69(svelte@5.53.5)
     devDependencies:
       '@internationalized/date':
         specifier: ^3.11.0
@@ -852,6 +855,11 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
+  svelte-dnd-action@0.9.69:
+    resolution: {integrity: sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw==}
+    peerDependencies:
+      svelte: '>=3.23.0 || ^5.0.0-next.0'
+
   svelte-toolbelt@0.10.6:
     resolution: {integrity: sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
@@ -1609,6 +1617,10 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-dnd-action@0.9.69(svelte@5.53.5):
+    dependencies:
+      svelte: 5.53.5
 
   svelte-toolbelt@0.10.6(@sveltejs/kit@2.53.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.5)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.5)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.5):
     dependencies:

--- a/front/src/routes/(app)/[workspace]/boards/[id]/+page.svelte
+++ b/front/src/routes/(app)/[workspace]/boards/[id]/+page.svelte
@@ -2,15 +2,17 @@
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
 
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import type { PageData } from './$types';
 	import type { Issue, Status } from '$lib/api';
+	import { issues as issuesApi, statuses as statusesApi } from '$lib/api';
+	import { dndzone } from 'svelte-dnd-action';
 	import * as Empty from '$lib/components/ui/empty/index.js';
 	import * as Sheet from '$lib/components/ui/sheet/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import LayoutIcon from '@lucide/svelte/icons/layout';
-	import { statuses as statusesApi } from '$lib/api';
 	import * as m from '$lib/paraglide/messages';
 	import { i18n } from '$lib/i18n.svelte';
 
@@ -40,14 +42,71 @@
 		low: 'bg-blue-100 text-blue-700'
 	};
 
-	// local reactive list — syncs from data on navigation, allows optimistic adds
+	// --- Local reactive state ---
 	let localStatuses = $state<Status[]>([]);
 	$effect(() => { localStatuses = [...data.statuses]; });
 
 	const sortedStatuses = $derived([...localStatuses].sort((a, b) => a.position - b.position));
 
-	function issuesForStatus(statusId: string): Issue[] {
-		return data.issues.filter((i) => i.status_id === statusId);
+	// Column items: one array per status, keyed by status id.
+	// svelte-dnd-action mutates these arrays directly.
+	let columns = $state<Record<string, Issue[]>>({});
+	let persistedColumns = $state<Record<string, Issue[]>>({});
+
+	$effect(() => {
+		const cols: Record<string, Issue[]> = {};
+		for (const status of localStatuses) {
+			cols[status.id] = data.issues
+				.filter((i) => i.status_id === status.id)
+				.sort((a, b) => a.status_position - b.status_position);
+		}
+		columns = cols;
+		persistedColumns = JSON.parse(JSON.stringify(cols));
+	});
+
+	// --- Drag and drop ---
+	const flipDurationMs = 200;
+
+	function handleConsider(statusId: string, e: CustomEvent<{ items: Issue[] }>) {
+		columns[statusId] = e.detail.items;
+	}
+
+	async function handleFinalize(statusId: string, e: CustomEvent<{ items: Issue[]; info: { id: string } }>) {
+		columns[statusId] = e.detail.items;
+		const draggedId = e.detail.info.id;
+
+		// Only the destination zone (the one containing the dragged item) should call move
+		const targetPosition = columns[statusId].findIndex((i) => i.id === draggedId);
+		if (targetPosition === -1) return;
+
+		try {
+			await issuesApi.move(data.board.project_id, draggedId, {
+				target_status_id: statusId,
+				target_position: targetPosition
+			});
+			persistedColumns = JSON.parse(JSON.stringify(columns));
+		} catch {
+			columns = JSON.parse(JSON.stringify(persistedColumns));
+			try {
+				const fresh = await issuesApi.list(data.board.project_id);
+				if (fresh) {
+					const cols: Record<string, Issue[]> = {};
+					for (const status of localStatuses) {
+						cols[status.id] = fresh
+							.filter((i) => i.status_id === status.id)
+							.sort((a, b) => a.status_position - b.status_position);
+					}
+					columns = cols;
+					persistedColumns = JSON.parse(JSON.stringify(cols));
+				}
+			} catch {
+				// keep persisted state
+			}
+		}
+	}
+
+	function issueHref(issue: Issue): string {
+		return `/${page.params.workspace}/projects/${data.board.project_id}/issues/${issue.id}`;
 	}
 
 	// --- Create status sheet ---
@@ -69,6 +128,8 @@
 				category
 			});
 			localStatuses = [...localStatuses, created];
+			columns[created.id] = [];
+			persistedColumns[created.id] = [];
 			sheetOpen = false;
 			resetForm();
 		} catch (err) {
@@ -92,40 +153,41 @@
 	</Empty.Root>
 {:else}
 	<div class="flex h-full min-h-0 gap-4 overflow-x-auto pb-4">
-		{#each sortedStatuses as status}
-			{@const columnIssues = issuesForStatus(status.id)}
+		{#each sortedStatuses as status (status.id)}
 			<div class="flex w-72 shrink-0 flex-col gap-3">
 				<div class="flex items-center gap-2 px-1">
 					<span class="text-sm font-medium">{status.name}</span>
 					<span class="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-						{columnIssues.length}
+						{(columns[status.id] ?? []).length}
 					</span>
 				</div>
-				<div class="flex flex-1 flex-col gap-2 overflow-y-auto rounded-lg bg-muted/40 p-2">
-					{#if columnIssues.length === 0}
-						<div class="flex items-center justify-center py-8 text-xs text-muted-foreground">
-							{t.noIssues}
+				<div
+					class="flex flex-1 flex-col gap-2 overflow-y-auto rounded-lg bg-muted/40 p-2"
+					use:dndzone={{ items: columns[status.id] ?? [], flipDurationMs, dropTargetStyle: {} }}
+					onconsider={(e) => handleConsider(status.id, e)}
+					onfinalize={(e) => handleFinalize(status.id, e)}
+				>
+					{#each columns[status.id] ?? [] as issue (issue.id)}
+						<div
+							class="flex flex-col gap-2 rounded-md border bg-background p-3 shadow-xs transition-colors hover:bg-muted/50 cursor-grab active:cursor-grabbing"
+							onclick={() => goto(issueHref(issue))}
+							onkeydown={(e) => { if (e.key === 'Enter') goto(issueHref(issue)); }}
+							role="button"
+							tabindex="0"
+						>
+							<div class="flex items-start justify-between gap-2">
+								<span class="text-sm leading-snug">{issue.title}</span>
+								{#if issue.priority && issue.priority !== 'none'}
+									<span
+										class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {priorityColors[issue.priority] ?? 'bg-muted text-muted-foreground'}"
+									>
+										{issue.priority}
+									</span>
+								{/if}
+							</div>
+							<span class="text-xs text-muted-foreground">#{issue.number}</span>
 						</div>
-					{:else}
-						{#each columnIssues as issue}
-							<a
-								href="/{page.params.workspace}/projects/{data.board.project_id}/issues/{issue.id}"
-								class="flex flex-col gap-2 rounded-md border bg-background p-3 shadow-xs transition-colors hover:bg-muted/50"
-							>
-								<div class="flex items-start justify-between gap-2">
-									<span class="text-sm leading-snug">{issue.title}</span>
-									{#if issue.priority && issue.priority !== 'none'}
-										<span
-											class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {priorityColors[issue.priority] ?? 'bg-muted text-muted-foreground'}"
-										>
-											{issue.priority}
-										</span>
-									{/if}
-								</div>
-								<span class="text-xs text-muted-foreground">#{issue.number}</span>
-							</a>
-						{/each}
-					{/if}
+					{/each}
 				</div>
 			</div>
 		{/each}

--- a/front/src/routes/(app)/boards/[id]/+page.svelte
+++ b/front/src/routes/(app)/boards/[id]/+page.svelte
@@ -2,14 +2,16 @@
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
 
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import type { PageData } from './$types';
 	import type { Issue, Status } from '$lib/api';
+	import { issues as issuesApi, statuses as statusesApi } from '$lib/api';
+	import { dndzone } from 'svelte-dnd-action';
 	import * as Empty from '$lib/components/ui/empty/index.js';
 	import * as Sheet from '$lib/components/ui/sheet/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import LayoutIcon from '@lucide/svelte/icons/layout';
-	import { statuses as statusesApi } from '$lib/api';
 	import * as m from '$lib/paraglide/messages';
 	import { i18n } from '$lib/i18n.svelte';
 
@@ -39,14 +41,68 @@
 		low: 'bg-blue-100 text-blue-700'
 	};
 
-	// local reactive list — syncs from data on navigation, allows optimistic adds
+	// --- Local reactive state ---
 	let localStatuses = $state<Status[]>([]);
 	$effect(() => { localStatuses = [...data.statuses]; });
 
 	const sortedStatuses = $derived([...localStatuses].sort((a, b) => a.position - b.position));
 
-	function issuesForStatus(statusId: string): Issue[] {
-		return data.issues.filter((i) => i.status_id === statusId);
+	let columns = $state<Record<string, Issue[]>>({});
+	let persistedColumns = $state<Record<string, Issue[]>>({});
+
+	$effect(() => {
+		const cols: Record<string, Issue[]> = {};
+		for (const status of localStatuses) {
+			cols[status.id] = data.issues
+				.filter((i) => i.status_id === status.id)
+				.sort((a, b) => a.status_position - b.status_position);
+		}
+		columns = cols;
+		persistedColumns = JSON.parse(JSON.stringify(cols));
+	});
+
+	// --- Drag and drop ---
+	const flipDurationMs = 200;
+
+	function handleConsider(statusId: string, e: CustomEvent<{ items: Issue[] }>) {
+		columns[statusId] = e.detail.items;
+	}
+
+	async function handleFinalize(statusId: string, e: CustomEvent<{ items: Issue[]; info: { id: string } }>) {
+		columns[statusId] = e.detail.items;
+		const draggedId = e.detail.info.id;
+
+		const targetPosition = columns[statusId].findIndex((i) => i.id === draggedId);
+		if (targetPosition === -1) return;
+
+		try {
+			await issuesApi.move(data.board.project_id, draggedId, {
+				target_status_id: statusId,
+				target_position: targetPosition
+			});
+			persistedColumns = JSON.parse(JSON.stringify(columns));
+		} catch {
+			columns = JSON.parse(JSON.stringify(persistedColumns));
+			try {
+				const fresh = await issuesApi.list(data.board.project_id);
+				if (fresh) {
+					const cols: Record<string, Issue[]> = {};
+					for (const status of localStatuses) {
+						cols[status.id] = fresh
+							.filter((i) => i.status_id === status.id)
+							.sort((a, b) => a.status_position - b.status_position);
+					}
+					columns = cols;
+					persistedColumns = JSON.parse(JSON.stringify(cols));
+				}
+			} catch {
+				// keep persisted state
+			}
+		}
+	}
+
+	function issueHref(issue: Issue): string {
+		return `/projects/${data.board.project_id}/issues/${issue.id}`;
 	}
 
 	// --- Create status sheet ---
@@ -68,6 +124,8 @@
 				category
 			});
 			localStatuses = [...localStatuses, created];
+			columns[created.id] = [];
+			persistedColumns[created.id] = [];
 			sheetOpen = false;
 			resetForm();
 		} catch (err) {
@@ -91,40 +149,41 @@
 	</Empty.Root>
 {:else}
 	<div class="flex h-full min-h-0 gap-4 overflow-x-auto pb-4">
-		{#each sortedStatuses as status}
-			{@const columnIssues = issuesForStatus(status.id)}
+		{#each sortedStatuses as status (status.id)}
 			<div class="flex w-72 shrink-0 flex-col gap-3">
 				<div class="flex items-center gap-2 px-1">
 					<span class="text-sm font-medium">{status.name}</span>
 					<span class="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-						{columnIssues.length}
+						{(columns[status.id] ?? []).length}
 					</span>
 				</div>
-				<div class="flex flex-1 flex-col gap-2 overflow-y-auto rounded-lg bg-muted/40 p-2">
-					{#if columnIssues.length === 0}
-						<div class="flex items-center justify-center py-8 text-xs text-muted-foreground">
-							{t.noIssues}
+				<div
+					class="flex flex-1 flex-col gap-2 overflow-y-auto rounded-lg bg-muted/40 p-2"
+					use:dndzone={{ items: columns[status.id] ?? [], flipDurationMs, dropTargetStyle: {} }}
+					onconsider={(e) => handleConsider(status.id, e)}
+					onfinalize={(e) => handleFinalize(status.id, e)}
+				>
+					{#each columns[status.id] ?? [] as issue (issue.id)}
+						<div
+							class="flex flex-col gap-2 rounded-md border bg-background p-3 shadow-xs transition-colors hover:bg-muted/50 cursor-grab active:cursor-grabbing"
+							onclick={() => goto(issueHref(issue))}
+							onkeydown={(e) => { if (e.key === 'Enter') goto(issueHref(issue)); }}
+							role="button"
+							tabindex="0"
+						>
+							<div class="flex items-start justify-between gap-2">
+								<span class="text-sm leading-snug">{issue.title}</span>
+								{#if issue.priority && issue.priority !== 'none'}
+									<span
+										class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {priorityColors[issue.priority] ?? 'bg-muted text-muted-foreground'}"
+									>
+										{issue.priority}
+									</span>
+								{/if}
+							</div>
+							<span class="text-xs text-muted-foreground">#{issue.number}</span>
 						</div>
-					{:else}
-						{#each columnIssues as issue}
-							<a
-								href="/projects/{data.board.project_id}/issues/{issue.id}"
-								class="flex flex-col gap-2 rounded-md border bg-background p-3 shadow-xs transition-colors hover:bg-muted/50"
-							>
-								<div class="flex items-start justify-between gap-2">
-									<span class="text-sm leading-snug">{issue.title}</span>
-									{#if issue.priority && issue.priority !== 'none'}
-										<span
-											class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {priorityColors[issue.priority] ?? 'bg-muted text-muted-foreground'}"
-										>
-											{issue.priority}
-										</span>
-									{/if}
-								</div>
-								<span class="text-xs text-muted-foreground">#{issue.number}</span>
-							</a>
-						{/each}
-					{/if}
+					{/each}
 				</div>
 			</div>
 		{/each}


### PR DESCRIPTION
## Summary
- Install `svelte-dnd-action` for Svelte 5 compatible drag-and-drop
- Add DnD to both board pages (workspace-scoped and non-scoped)
- Optimistic UI update on drop; revert + refetch on API failure
- Cards use `div` with `onclick` instead of `<a>` for DnD compatibility
- Empty columns remain droppable

## Test plan
- [x] `pnpm build`
- [x] `pnpm check` (only pre-existing async_hooks)
- [x] Manual: drag issue between columns → status changes
- [x] Manual: drag within column → reorders
- [x] Manual: click card (no drag) → navigates to detail
- [x] Manual: failed move → reverts to previous state
- [x] Manual: empty column accepts drops