### PR TITLE
feat(ui): add basic board filters and close Phase 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 - Added workspace membership enforcement on all API routes (read and write)
 - Added project-member creation guard: target user must be a workspace member
 - Added `sessions.IsAuthError` helper for centralized error classification
+- Added basic board filters: client-side filtering by assignee, priority, and issue type
 - Added board drag-and-drop: move issues between status columns and reorder within columns via `svelte-dnd-action`
 - Added issue detail page at `/{workspace}/projects/{id}/issues/{issueID}` with edit for title, description, priority, assignee, due date
 - Added clickable issue cards on board view linking to issue detail

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ What is shipped today:
 - Boards, statuses, issue types, issues CRUD.
 - Board drag-and-drop: move issues between columns and reorder within columns.
 - Issue detail page: view and edit title, description, priority, assignee, due date.
+- Basic board filters: client-side filtering by assignee, priority, and issue type.
 - Local email/password authentication with server-side sessions.
 - Workspace and project membership enforcement with admin/owner roles.
 - Internationalization: English and Spanish.
@@ -64,7 +65,7 @@ See [docs/05-roadmap.md](docs/05-roadmap.md) for the full phased roadmap.
 
 Summary:
 - **Phase 0 — Foundation** `[shipped]` — core backend, domains, templates, i18n.
-- **Phase 1 — MVP hardening** `[in progress]` — full auth, membership enforcement, board UI, issue detail.
+- **Phase 1 — MVP hardening** `[shipped]` — full auth, membership enforcement, board UI, issue detail, board filters.
 - **Phase 1.5 — Identity, onboarding, and instance admin** `[planned]` — SMTP, password reset, invitations, SSO/OIDC, first-install bootstrap.
 - **Phase 2 — Software workflow depth** `[planned]` — issue hierarchy, sprints, backlog, planning board.
 - **Phase 3 — Documentation-led planning** `[planned]` — project pages, decision records, doc↔work item links.

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -39,7 +39,7 @@ The core platform infrastructure and first working end-to-end flow.
 
 ---
 
-## Phase 1 — MVP hardening `[in progress]`
+## Phase 1 — MVP hardening `[shipped]`
 
 Close the gap between what the backend supports and what the UI delivers. Deliver a fully usable, secure baseline.
 
@@ -55,7 +55,7 @@ Close the gap between what the backend supports and what the UI delivers. Delive
 - PR 21 `[shipped]` — Add `due_date` to issue update and create API contracts.
 - PR 22 `[shipped]` — Issue detail page: view and edit title, description, priority, assignee, due date.
 - PR 23 `[shipped]` — Board drag-and-drop: move issues between columns with optimistic updates.
-- PR 24 `[pending]` — Basic board filters: client-side filtering by assignee, priority, and issue type.
+- PR 24 `[shipped]` — Basic board filters: client-side filtering by assignee, priority, and issue type.
 
 ---
 

--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -75,6 +75,12 @@
   "settings_users_title": "Users",
   "settings_account_title": "Account",
 
+  "board_filter_assignee": "Assignee",
+  "board_filter_priority": "Priority",
+  "board_filter_type": "Type",
+  "board_filter_all": "All",
+  "board_filter_clear": "Clear filters",
+
   "issue_detail_title": "Title",
   "issue_detail_description": "Description",
   "issue_detail_priority": "Priority",

--- a/front/messages/es.json
+++ b/front/messages/es.json
@@ -75,6 +75,12 @@
   "settings_users_title": "Usuarios",
   "settings_account_title": "Cuenta",
 
+  "board_filter_assignee": "Asignado",
+  "board_filter_priority": "Prioridad",
+  "board_filter_type": "Tipo",
+  "board_filter_all": "Todos",
+  "board_filter_clear": "Limpiar filtros",
+
   "issue_detail_title": "Título",
   "issue_detail_description": "Descripción",
   "issue_detail_priority": "Prioridad",

--- a/front/src/routes/(app)/[workspace]/boards/[id]/+page.svelte
+++ b/front/src/routes/(app)/[workspace]/boards/[id]/+page.svelte
@@ -13,6 +13,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import LayoutIcon from '@lucide/svelte/icons/layout';
+	import FilterXIcon from '@lucide/svelte/icons/filter-x';
 	import * as m from '$lib/paraglide/messages';
 	import { i18n } from '$lib/i18n.svelte';
 
@@ -31,7 +32,12 @@
 			cancel:         m.workspace_cancel(),
 			catTodo:        m.status_category_todo(),
 			catInProgress:  m.status_category_in_progress(),
-			catDone:        m.status_category_done()
+			catDone:        m.status_category_done(),
+			filterAssignee: m.board_filter_assignee(),
+			filterPriority: m.board_filter_priority(),
+			filterType:     m.board_filter_type(),
+			filterAll:      m.board_filter_all(),
+			filterClear:    m.board_filter_clear()
 		};
 	});
 
@@ -48,20 +54,63 @@
 
 	const sortedStatuses = $derived([...localStatuses].sort((a, b) => a.position - b.position));
 
-	// Column items: one array per status, keyed by status id.
-	// svelte-dnd-action mutates these arrays directly.
-	let columns = $state<Record<string, Issue[]>>({});
+	// All columns (unfiltered) — source of truth for positions and DnD
+	// Initialized from data.issues only when the data reference changes (navigation),
+	// not when localStatuses changes (e.g. creating a new status).
+	let allColumns = $state<Record<string, Issue[]>>({});
 	let persistedColumns = $state<Record<string, Issue[]>>({});
 
-	$effect(() => {
+	function buildColumns(issueList: Issue[], statusList: Status[]): Record<string, Issue[]> {
 		const cols: Record<string, Issue[]> = {};
-		for (const status of localStatuses) {
-			cols[status.id] = data.issues
+		for (const status of statusList) {
+			cols[status.id] = issueList
 				.filter((i) => i.status_id === status.id)
 				.sort((a, b) => a.status_position - b.status_position);
 		}
-		columns = cols;
+		return cols;
+	}
+
+	$effect(() => {
+		const cols = buildColumns(data.issues, data.statuses);
+		allColumns = cols;
 		persistedColumns = JSON.parse(JSON.stringify(cols));
+	});
+
+	// --- Filters (reset on board change) ---
+	let filterAssignee = $state('');
+	let filterPriority = $state('');
+	let filterType = $state('');
+
+	$effect(() => {
+		data.board.id;
+		filterAssignee = '';
+		filterPriority = '';
+		filterType = '';
+	});
+
+	const hasFilters = $derived(filterAssignee !== '' || filterPriority !== '' || filterType !== '');
+
+	function matchesFilters(issue: Issue): boolean {
+		if (filterAssignee && issue.assignee_id !== filterAssignee) return false;
+		if (filterPriority && issue.priority !== filterPriority) return false;
+		if (filterType && issue.issue_type_id !== filterType) return false;
+		return true;
+	}
+
+	function clearFilters() {
+		filterAssignee = '';
+		filterPriority = '';
+		filterType = '';
+	}
+
+	// Filtered columns — what DnD zones render
+	let columns = $state<Record<string, Issue[]>>({});
+	$effect(() => {
+		const cols: Record<string, Issue[]> = {};
+		for (const statusId of Object.keys(allColumns)) {
+			cols[statusId] = allColumns[statusId].filter(matchesFilters);
+		}
+		columns = cols;
 	});
 
 	// --- Drag and drop ---
@@ -75,18 +124,45 @@
 		columns[statusId] = e.detail.items;
 		const draggedId = e.detail.info.id;
 
-		// Only the destination zone (the one containing the dragged item) should call move
-		const targetPosition = columns[statusId].findIndex((i) => i.id === draggedId);
-		if (targetPosition === -1) return;
+		const visibleIdx = columns[statusId].findIndex((i) => i.id === draggedId);
+		if (visibleIdx === -1) return;
+
+		// Remove dragged item from all columns first, then calculate position
+		const draggedIssue = columns[statusId][visibleIdx];
+		for (const sid of Object.keys(allColumns)) {
+			allColumns[sid] = allColumns[sid].filter((i) => i.id !== draggedId);
+		}
+
+		// Calculate target_position against the full column (with dragged item already removed)
+		const fullCol = allColumns[statusId];
+		let targetPosition: number;
+
+		if (!hasFilters) {
+			targetPosition = visibleIdx;
+		} else {
+			const prevVisible = visibleIdx > 0 ? columns[statusId][visibleIdx - 1] : null;
+			const nextVisible = visibleIdx < columns[statusId].length - 1 ? columns[statusId][visibleIdx + 1] : null;
+
+			if (prevVisible) {
+				targetPosition = fullCol.findIndex((i) => i.id === prevVisible.id) + 1;
+			} else if (nextVisible) {
+				targetPosition = fullCol.findIndex((i) => i.id === nextVisible.id);
+			} else {
+				targetPosition = fullCol.length;
+			}
+		}
+
+		// Insert at calculated position
+		allColumns[statusId].splice(targetPosition, 0, { ...draggedIssue, status_id: statusId });
 
 		try {
 			await issuesApi.move(data.board.project_id, draggedId, {
 				target_status_id: statusId,
 				target_position: targetPosition
 			});
-			persistedColumns = JSON.parse(JSON.stringify(columns));
+			persistedColumns = JSON.parse(JSON.stringify(allColumns));
 		} catch {
-			columns = JSON.parse(JSON.stringify(persistedColumns));
+			allColumns = JSON.parse(JSON.stringify(persistedColumns));
 			try {
 				const fresh = await issuesApi.list(data.board.project_id);
 				if (fresh) {
@@ -96,7 +172,7 @@
 							.filter((i) => i.status_id === status.id)
 							.sort((a, b) => a.status_position - b.status_position);
 					}
-					columns = cols;
+					allColumns = cols;
 					persistedColumns = JSON.parse(JSON.stringify(cols));
 				}
 			} catch {
@@ -128,7 +204,7 @@
 				category
 			});
 			localStatuses = [...localStatuses, created];
-			columns[created.id] = [];
+			allColumns[created.id] = [];
 			persistedColumns[created.id] = [];
 			sheetOpen = false;
 			resetForm();
@@ -138,6 +214,8 @@
 			saving = false;
 		}
 	}
+
+	const selectClass = 'flex h-8 rounded-md border border-input bg-background px-2 py-1 text-xs shadow-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
 </script>
 
 {#if sortedStatuses.length === 0}
@@ -152,6 +230,39 @@
 		</Empty.Content>
 	</Empty.Root>
 {:else}
+	<!-- Filter bar -->
+	<div class="mb-4 flex flex-wrap items-center gap-3">
+		<select bind:value={filterAssignee} class={selectClass}>
+			<option value="">{t.filterAssignee}: {t.filterAll}</option>
+			{#each data.members as member}
+				<option value={member.user_id}>{member.user_id.slice(0, 8)}</option>
+			{/each}
+		</select>
+
+		<select bind:value={filterPriority} class={selectClass}>
+			<option value="">{t.filterPriority}: {t.filterAll}</option>
+			<option value="critical">Critical</option>
+			<option value="high">High</option>
+			<option value="medium">Medium</option>
+			<option value="low">Low</option>
+		</select>
+
+		<select bind:value={filterType} class={selectClass}>
+			<option value="">{t.filterType}: {t.filterAll}</option>
+			{#each data.issueTypes as type}
+				<option value={type.id}>{type.name}</option>
+			{/each}
+		</select>
+
+		{#if hasFilters}
+			<Button variant="ghost" size="sm" onclick={clearFilters}>
+				<FilterXIcon class="mr-1 size-3.5" />
+				{t.filterClear}
+			</Button>
+		{/if}
+	</div>
+
+	<!-- Board columns -->
 	<div class="flex h-full min-h-0 gap-4 overflow-x-auto pb-4">
 		{#each sortedStatuses as status (status.id)}
 			<div class="flex w-72 shrink-0 flex-col gap-3">

--- a/front/src/routes/(app)/[workspace]/boards/[id]/+page.ts
+++ b/front/src/routes/(app)/[workspace]/boards/[id]/+page.ts
@@ -1,21 +1,27 @@
 // Copyright (c) 2025 Start Codex SAS. All rights reserved.
 // SPDX-License-Identifier: BUSL-1.1
 
-import { boards, statuses, issues } from '$lib/api';
+import { boards, statuses, issues, projects, issueTypes, workspaces } from '$lib/api';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params }) => {
 	const board = await boards.get(params.id);
+	const project = await projects.get(board.project_id);
 
-	const [statusList, issueList] = await Promise.all([
+	const [statusList, issueList, typeList, memberList] = await Promise.all([
 		statuses.list(board.project_id).then((r) => r ?? []),
-		issues.list(board.project_id).then((r) => r ?? [])
+		issues.list(board.project_id).then((r) => r ?? []),
+		issueTypes.list(board.project_id).then((r) => r ?? []),
+		workspaces.members.list(project.workspace_id).then((r) => r ?? [])
 	]);
 
 	return {
 		board,
+		project,
 		statuses: statusList,
 		issues: issueList,
+		issueTypes: typeList,
+		members: memberList,
 		breadcrumb: [{ label: board.name }]
 	};
 };

--- a/front/src/routes/(app)/boards/[id]/+page.svelte
+++ b/front/src/routes/(app)/boards/[id]/+page.svelte
@@ -12,6 +12,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import LayoutIcon from '@lucide/svelte/icons/layout';
+	import FilterXIcon from '@lucide/svelte/icons/filter-x';
 	import * as m from '$lib/paraglide/messages';
 	import { i18n } from '$lib/i18n.svelte';
 
@@ -30,7 +31,12 @@
 			cancel:         m.workspace_cancel(),
 			catTodo:        m.status_category_todo(),
 			catInProgress:  m.status_category_in_progress(),
-			catDone:        m.status_category_done()
+			catDone:        m.status_category_done(),
+			filterAssignee: m.board_filter_assignee(),
+			filterPriority: m.board_filter_priority(),
+			filterType:     m.board_filter_type(),
+			filterAll:      m.board_filter_all(),
+			filterClear:    m.board_filter_clear()
 		};
 	});
 
@@ -47,18 +53,63 @@
 
 	const sortedStatuses = $derived([...localStatuses].sort((a, b) => a.position - b.position));
 
-	let columns = $state<Record<string, Issue[]>>({});
+	// All columns (unfiltered) — source of truth for positions and DnD
+	// Initialized from data.issues only when the data reference changes (navigation),
+	// not when localStatuses changes (e.g. creating a new status).
+	let allColumns = $state<Record<string, Issue[]>>({});
 	let persistedColumns = $state<Record<string, Issue[]>>({});
 
-	$effect(() => {
+	function buildColumns(issueList: Issue[], statusList: Status[]): Record<string, Issue[]> {
 		const cols: Record<string, Issue[]> = {};
-		for (const status of localStatuses) {
-			cols[status.id] = data.issues
+		for (const status of statusList) {
+			cols[status.id] = issueList
 				.filter((i) => i.status_id === status.id)
 				.sort((a, b) => a.status_position - b.status_position);
 		}
-		columns = cols;
+		return cols;
+	}
+
+	$effect(() => {
+		const cols = buildColumns(data.issues, data.statuses);
+		allColumns = cols;
 		persistedColumns = JSON.parse(JSON.stringify(cols));
+	});
+
+	// --- Filters (reset on board change) ---
+	let filterAssignee = $state('');
+	let filterPriority = $state('');
+	let filterType = $state('');
+
+	$effect(() => {
+		data.board.id;
+		filterAssignee = '';
+		filterPriority = '';
+		filterType = '';
+	});
+
+	const hasFilters = $derived(filterAssignee !== '' || filterPriority !== '' || filterType !== '');
+
+	function matchesFilters(issue: Issue): boolean {
+		if (filterAssignee && issue.assignee_id !== filterAssignee) return false;
+		if (filterPriority && issue.priority !== filterPriority) return false;
+		if (filterType && issue.issue_type_id !== filterType) return false;
+		return true;
+	}
+
+	function clearFilters() {
+		filterAssignee = '';
+		filterPriority = '';
+		filterType = '';
+	}
+
+	// Filtered columns — what DnD zones render
+	let columns = $state<Record<string, Issue[]>>({});
+	$effect(() => {
+		const cols: Record<string, Issue[]> = {};
+		for (const statusId of Object.keys(allColumns)) {
+			cols[statusId] = allColumns[statusId].filter(matchesFilters);
+		}
+		columns = cols;
 	});
 
 	// --- Drag and drop ---
@@ -72,17 +123,45 @@
 		columns[statusId] = e.detail.items;
 		const draggedId = e.detail.info.id;
 
-		const targetPosition = columns[statusId].findIndex((i) => i.id === draggedId);
-		if (targetPosition === -1) return;
+		const visibleIdx = columns[statusId].findIndex((i) => i.id === draggedId);
+		if (visibleIdx === -1) return;
+
+		// Remove dragged item from all columns first, then calculate position
+		const draggedIssue = columns[statusId][visibleIdx];
+		for (const sid of Object.keys(allColumns)) {
+			allColumns[sid] = allColumns[sid].filter((i) => i.id !== draggedId);
+		}
+
+		// Calculate target_position against the full column (with dragged item already removed)
+		const fullCol = allColumns[statusId];
+		let targetPosition: number;
+
+		if (!hasFilters) {
+			targetPosition = visibleIdx;
+		} else {
+			const prevVisible = visibleIdx > 0 ? columns[statusId][visibleIdx - 1] : null;
+			const nextVisible = visibleIdx < columns[statusId].length - 1 ? columns[statusId][visibleIdx + 1] : null;
+
+			if (prevVisible) {
+				targetPosition = fullCol.findIndex((i) => i.id === prevVisible.id) + 1;
+			} else if (nextVisible) {
+				targetPosition = fullCol.findIndex((i) => i.id === nextVisible.id);
+			} else {
+				targetPosition = fullCol.length;
+			}
+		}
+
+		// Insert at calculated position
+		allColumns[statusId].splice(targetPosition, 0, { ...draggedIssue, status_id: statusId });
 
 		try {
 			await issuesApi.move(data.board.project_id, draggedId, {
 				target_status_id: statusId,
 				target_position: targetPosition
 			});
-			persistedColumns = JSON.parse(JSON.stringify(columns));
+			persistedColumns = JSON.parse(JSON.stringify(allColumns));
 		} catch {
-			columns = JSON.parse(JSON.stringify(persistedColumns));
+			allColumns = JSON.parse(JSON.stringify(persistedColumns));
 			try {
 				const fresh = await issuesApi.list(data.board.project_id);
 				if (fresh) {
@@ -92,7 +171,7 @@
 							.filter((i) => i.status_id === status.id)
 							.sort((a, b) => a.status_position - b.status_position);
 					}
-					columns = cols;
+					allColumns = cols;
 					persistedColumns = JSON.parse(JSON.stringify(cols));
 				}
 			} catch {
@@ -124,7 +203,7 @@
 				category
 			});
 			localStatuses = [...localStatuses, created];
-			columns[created.id] = [];
+			allColumns[created.id] = [];
 			persistedColumns[created.id] = [];
 			sheetOpen = false;
 			resetForm();
@@ -134,6 +213,8 @@
 			saving = false;
 		}
 	}
+
+	const selectClass = 'flex h-8 rounded-md border border-input bg-background px-2 py-1 text-xs shadow-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
 </script>
 
 {#if sortedStatuses.length === 0}
@@ -148,6 +229,39 @@
 		</Empty.Content>
 	</Empty.Root>
 {:else}
+	<!-- Filter bar -->
+	<div class="mb-4 flex flex-wrap items-center gap-3">
+		<select bind:value={filterAssignee} class={selectClass}>
+			<option value="">{t.filterAssignee}: {t.filterAll}</option>
+			{#each data.members as member}
+				<option value={member.user_id}>{member.user_id.slice(0, 8)}</option>
+			{/each}
+		</select>
+
+		<select bind:value={filterPriority} class={selectClass}>
+			<option value="">{t.filterPriority}: {t.filterAll}</option>
+			<option value="critical">Critical</option>
+			<option value="high">High</option>
+			<option value="medium">Medium</option>
+			<option value="low">Low</option>
+		</select>
+
+		<select bind:value={filterType} class={selectClass}>
+			<option value="">{t.filterType}: {t.filterAll}</option>
+			{#each data.issueTypes as type}
+				<option value={type.id}>{type.name}</option>
+			{/each}
+		</select>
+
+		{#if hasFilters}
+			<Button variant="ghost" size="sm" onclick={clearFilters}>
+				<FilterXIcon class="mr-1 size-3.5" />
+				{t.filterClear}
+			</Button>
+		{/if}
+	</div>
+
+	<!-- Board columns -->
 	<div class="flex h-full min-h-0 gap-4 overflow-x-auto pb-4">
 		{#each sortedStatuses as status (status.id)}
 			<div class="flex w-72 shrink-0 flex-col gap-3">

--- a/front/src/routes/(app)/boards/[id]/+page.ts
+++ b/front/src/routes/(app)/boards/[id]/+page.ts
@@ -1,21 +1,27 @@
 // Copyright (c) 2025 Start Codex SAS. All rights reserved.
 // SPDX-License-Identifier: BUSL-1.1
 
-import { boards, statuses, issues } from '$lib/api';
+import { boards, statuses, issues, projects, issueTypes, workspaces } from '$lib/api';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params }) => {
 	const board = await boards.get(params.id);
+	const project = await projects.get(board.project_id);
 
-	const [statusList, issueList] = await Promise.all([
-		statuses.list(board.project_id).then(r => r ?? []),
-		issues.list(board.project_id).then(r => r ?? [])
+	const [statusList, issueList, typeList, memberList] = await Promise.all([
+		statuses.list(board.project_id).then((r) => r ?? []),
+		issues.list(board.project_id).then((r) => r ?? []),
+		issueTypes.list(board.project_id).then((r) => r ?? []),
+		workspaces.members.list(project.workspace_id).then((r) => r ?? [])
 	]);
 
 	return {
 		board,
+		project,
 		statuses: statusList,
 		issues: issueList,
+		issueTypes: typeList,
+		members: memberList,
 		breadcrumb: [{ label: board.name }]
 	};
 };


### PR DESCRIPTION
## Summary
- Add client-side filter bar to board: assignee, priority, issue type
- Extend board load to fetch issue types and workspace members
- DnD works with active filters (position calculated against full column)
- Clear filters button restores all cards
- i18n for EN + ES
- Phase 1 marked as shipped

## Test plan
- [x] `pnpm build`
- [x] `go build ./...`
- [x] `go test -count=1 ./cmd/server/...`
- [x] Manual: filter by assignee, priority, type individually
- [x] Manual: combine filters → intersection
- [x] Manual: clear filters → all cards
- [x] Manual: drag with filters active → correct position