### PR TITLE
feat(auth): add optional email verification with admin toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Contributors should add ongoing changes to the `Unreleased` section. When a mile
 ## [Unreleased]
 
 ### Added
+- Added optional email verification: admin toggle, verification banner, verify-email page, resend endpoint
+- Added `email_verified_at` to users; bootstrap admin is pre-verified
+- Added `email_verification_required` in `/auth/me` response for frontend
+- Added admin verification settings page at `/admin/verification`
 - Added invitation management page in workspace settings (admin-only: invite, list, resend, revoke)
 - Added invitation acceptance page at `/invitations/accept` (authenticated accept, new user registration, email mismatch guard)
 - Added `next` param support in login form for post-login redirect

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ What is shipped today:
 - Issue detail page: view and edit title, description, priority, assignee, due date.
 - Basic board filters: client-side filtering by assignee, priority, and issue type.
 - Instance bootstrap: first-install setup wizard creates the initial global admin.
+- Optional email verification with admin toggle and soft enforcement (banner, no blocking).
 - Workspace invitations: admin invite page, accept page with registration, login redirect with `next`.
 - Forgot/reset password pages with email token (1h TTL, one-time use, session invalidation).
 - Change password with session invalidation on other devices.

--- a/cmd/server/api.go
+++ b/cmd/server/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/start-codex/tookly/internal/boards"
+	"github.com/start-codex/tookly/internal/emailverification"
 	"github.com/start-codex/tookly/internal/instance"
 	"github.com/start-codex/tookly/internal/invitations"
 	"github.com/start-codex/tookly/internal/issues"
@@ -27,6 +28,7 @@ func newAPIHandler(db *sqlx.DB) http.Handler {
 	instance.RegisterRoutes(api, db)
 	users.RegisterRoutes(api, db)
 	passwordreset.RegisterRoutes(api, db)
+	emailverification.RegisterRoutes(api, db)
 	workspaces.RegisterRoutes(api, db)
 	invitations.RegisterRoutes(api, db)
 	projects.RegisterRoutes(api, db)

--- a/cmd/server/middleware.go
+++ b/cmd/server/middleware.go
@@ -68,6 +68,7 @@ var staticPublicRoutes = []struct{ method, path string }{
 	{"POST", "/auth/reset-password"},
 	{"GET", "/invitations/accept"},
 	{"POST", "/invitations/accept"},
+	{"POST", "/auth/verify-email"},
 }
 
 // isPublicRoute returns:

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -63,7 +63,7 @@ Close the gap between what the backend supports and what the UI delivers. Delive
 
 Make self-hosted deployments operable beyond basic local login. This phase covers the missing identity and bootstrap capabilities that sit between MVP auth and broader platform workflows.
 
-**Instance configuration, bootstrap, email, admin settings, password management, and invitations** (PRs #25–#34 `[shipped]`)
+**Identity, onboarding, and instance admin** (PRs #25–#35 `[shipped]`)
 - `instance_config` key-value table for instance-level settings.
 - `internal/instance` package: `GetConfig`, `SetConfig`, `IsInitialized`, `Bootstrap`.
 - `POST /instance/bootstrap`: atomic first-install flow creates global admin.

--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -139,6 +139,18 @@
   "accept_passwords_mismatch": "Passwords do not match",
   "accept_password_too_short": "Password must be at least 8 characters",
 
+  "verify_banner": "Please verify your email address.",
+  "verify_resend": "Resend verification email",
+  "verify_resent": "Verification email sent",
+  "verify_resend_error": "Failed to send verification email",
+  "verify_success": "Your email has been verified!",
+  "verify_invalid": "This verification link is invalid or has expired.",
+  "verify_error": "Something went wrong. Please try again.",
+  "admin_verification_title": "Email Verification",
+  "admin_verification_toggle": "Require email verification for new accounts",
+  "admin_verification_enabled": "Email verification is enabled",
+  "admin_verification_disabled": "Email verification is disabled",
+
   "nav_admin": "Admin",
   "admin_title": "Administration",
   "admin_smtp_title": "SMTP Configuration",

--- a/front/messages/es.json
+++ b/front/messages/es.json
@@ -139,6 +139,18 @@
   "accept_passwords_mismatch": "Las contraseñas no coinciden",
   "accept_password_too_short": "La contraseña debe tener al menos 8 caracteres",
 
+  "verify_banner": "Por favor verifica tu dirección de correo electrónico.",
+  "verify_resend": "Reenviar correo de verificación",
+  "verify_resent": "Correo de verificación enviado",
+  "verify_resend_error": "Error al enviar correo de verificación",
+  "verify_success": "Tu correo ha sido verificado.",
+  "verify_invalid": "Este enlace de verificación es inválido o ha expirado.",
+  "verify_error": "Algo salió mal. Intenta de nuevo.",
+  "admin_verification_title": "Verificación de correo",
+  "admin_verification_toggle": "Requerir verificación de correo para nuevas cuentas",
+  "admin_verification_enabled": "Verificación de correo habilitada",
+  "admin_verification_disabled": "Verificación de correo deshabilitada",
+
   "nav_admin": "Admin",
   "admin_title": "Administración",
   "admin_smtp_title": "Configuración SMTP",

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -51,6 +51,10 @@ export const instance = {
 	status: () => get<{ initialized: boolean }>('/instance/status'),
 	bootstrap: (body: { email: string; name: string; password: string }) =>
 		post<User>('/instance/bootstrap', body),
+	verification: {
+		get: () => get<{ required: boolean }>('/instance/verification'),
+		save: (body: { required: boolean }) => post<{ status: string }>('/instance/verification', body)
+	},
 	smtp: {
 		get: () => get<SMTPConfig>('/instance/smtp'),
 		save: (body: SMTPConfig) => post<{ status: string }>('/instance/smtp', body),
@@ -61,13 +65,15 @@ export const instance = {
 // --- Auth ---
 export const auth = {
 	login: (body: { email: string; password: string }) => post<User>('/auth/login', body),
-	me: () => get<{ authenticated: boolean; user?: User }>('/auth/me'),
+	me: () => get<{ authenticated: boolean; user?: User; email_verification_required?: boolean }>('/auth/me'),
 	logout: () => post<void>('/auth/logout', {}),
 	changePassword: (body: { current_password: string; new_password: string }) =>
 		post<void>('/auth/change-password', body),
 	forgotPassword: (body: { email: string }) => post<void>('/auth/forgot-password', body),
 	resetPassword: (body: { token: string; new_password: string }) =>
-		post<void>('/auth/reset-password', body)
+		post<void>('/auth/reset-password', body),
+	verifyEmail: (body: { token: string }) => post<void>('/auth/verify-email', body),
+	resendVerification: () => post<void>('/auth/resend-verification', {})
 };
 
 // --- Users ---
@@ -188,6 +194,7 @@ export const invitations = {
 // --- Types ---
 export interface User {
 	id: string; email: string; name: string; is_instance_admin: boolean;
+	email_verified_at?: string;
 	created_at: string; updated_at: string; archived_at?: string;
 }
 export interface Workspace {

--- a/front/src/routes/(app)/+layout.svelte
+++ b/front/src/routes/(app)/+layout.svelte
@@ -3,14 +3,73 @@
 
 <script lang="ts">
 	import { page } from '$app/state';
+	import type { LayoutData } from './$types';
 	import { currentUser, logout } from '$lib/stores/auth';
+	import { auth } from '$lib/api';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import LogOutIcon from '@lucide/svelte/icons/log-out';
+	import * as m from '$lib/paraglide/messages';
+	import { i18n } from '$lib/i18n.svelte';
 
-	let { children } = $props();
+	let { children, data }: { children: any; data: LayoutData } = $props();
 
 	const isWorkspaceRoute = $derived(!!page.params.workspace);
+
+	const showVerifyBanner = $derived(
+		!!$currentUser &&
+		!$currentUser.email_verified_at &&
+		data.emailVerificationRequired
+	);
+
+	const t = $derived.by(() => {
+		i18n.locale;
+		return {
+			verifyBanner: m.verify_banner(),
+			resend: m.verify_resend(),
+			resent: m.verify_resent(),
+			resendError: m.verify_resend_error()
+		};
+	});
+
+	let resending = $state(false);
+	let resendSuccess = $state(false);
+	let resendError = $state('');
+
+	async function handleResend() {
+		resending = true;
+		resendSuccess = false;
+		resendError = '';
+		try {
+			await auth.resendVerification();
+			resendSuccess = true;
+			setTimeout(() => { resendSuccess = false; }, 5000);
+		} catch {
+			resendError = t.resendError;
+		} finally {
+			resending = false;
+		}
+	}
 </script>
+
+<!-- Verification banner (above everything) -->
+{#if showVerifyBanner}
+	<div class="bg-yellow-50 border-b border-yellow-200 px-4 py-2 text-center text-sm text-yellow-800">
+		{t.verifyBanner}
+		<button
+			class="ml-2 underline underline-offset-4 hover:text-yellow-900"
+			onclick={handleResend}
+			disabled={resending}
+		>
+			{resending ? '...' : t.resend}
+		</button>
+		{#if resendSuccess}
+			<span class="ml-2 text-green-700">{t.resent}</span>
+		{/if}
+		{#if resendError}
+			<span class="ml-2 text-red-700">{resendError}</span>
+		{/if}
+	</div>
+{/if}
 
 {#if isWorkspaceRoute}
 	{@render children()}

--- a/front/src/routes/(app)/+layout.ts
+++ b/front/src/routes/(app)/+layout.ts
@@ -3,19 +3,24 @@
 
 import { browser } from '$app/environment';
 import { redirect } from '@sveltejs/kit';
-import { instance } from '$lib/api';
-import { restore } from '$lib/stores/auth';
+import { instance, auth } from '$lib/api';
+import { login } from '$lib/stores/auth';
 
 export const ssr = false;
 
 export async function load() {
-	if (!browser) return { user: null };
+	if (!browser) return { user: null, emailVerificationRequired: false };
 
 	const { initialized } = await instance.status();
 	if (!initialized) redirect(302, '/setup');
 
-	const user = await restore();
-	if (!user) redirect(302, '/login');
+	const me = await auth.me();
+	if (!me.authenticated || !me.user) redirect(302, '/login');
 
-	return { user };
+	login(me.user!);
+
+	return {
+		user: me.user!,
+		emailVerificationRequired: me.email_verification_required ?? false
+	};
 }

--- a/front/src/routes/(app)/[workspace]/settings/+page.ts
+++ b/front/src/routes/(app)/[workspace]/settings/+page.ts
@@ -4,6 +4,6 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = () => {
-	redirect(302, '/settings/preferences');
+export const load: PageLoad = ({ params }) => {
+	redirect(302, `/${params.workspace}/settings/preferences`);
 };

--- a/front/src/routes/(app)/admin/+layout.svelte
+++ b/front/src/routes/(app)/admin/+layout.svelte
@@ -4,6 +4,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import MailIcon from '@lucide/svelte/icons/mail';
+	import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
 	import * as m from '$lib/paraglide/messages';
 	import { i18n } from '$lib/i18n.svelte';
 
@@ -12,7 +13,8 @@
 	const navItems = $derived.by(() => {
 		i18n.locale;
 		return [
-			{ href: '/admin/smtp', label: m.admin_smtp_title(), icon: MailIcon }
+			{ href: '/admin/smtp', label: m.admin_smtp_title(), icon: MailIcon },
+			{ href: '/admin/verification', label: m.admin_verification_title(), icon: ShieldCheckIcon }
 		];
 	});
 

--- a/front/src/routes/(app)/admin/verification/+page.svelte
+++ b/front/src/routes/(app)/admin/verification/+page.svelte
@@ -1,0 +1,72 @@
+<!-- Copyright (c) 2025 Start Codex SAS. All rights reserved. -->
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { instance } from '$lib/api';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as m from '$lib/paraglide/messages';
+	import { i18n } from '$lib/i18n.svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	const t = $derived.by(() => {
+		i18n.locale;
+		return {
+			title: m.admin_verification_title(),
+			toggle: m.admin_verification_toggle(),
+			enabled: m.admin_verification_enabled(),
+			disabled: m.admin_verification_disabled()
+		};
+	});
+
+	let required = $state(false);
+	let saving = $state(false);
+	let saved = $state(false);
+
+	$effect(() => { required = data.verificationRequired; });
+
+	async function handleToggle() {
+		saving = true;
+		saved = false;
+		try {
+			required = !required;
+			await instance.verification.save({ required });
+			saved = true;
+			setTimeout(() => { saved = false; }, 3000);
+		} catch {
+			required = !required; // revert
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<div class="space-y-6">
+	<h2 class="text-lg font-semibold">{t.title}</h2>
+
+	<Card.Root>
+		<Card.Content class="flex items-center justify-between pt-6">
+			<div>
+				<p class="text-sm font-medium">{t.toggle}</p>
+				<p class="text-xs text-muted-foreground">
+					{required ? t.enabled : t.disabled}
+				</p>
+			</div>
+			<div class="flex items-center gap-3">
+				<Button
+					variant={required ? 'default' : 'outline'}
+					size="sm"
+					onclick={handleToggle}
+					disabled={saving}
+				>
+					{required ? 'On' : 'Off'}
+				</Button>
+				{#if saved}
+					<span class="text-xs text-green-600">Saved</span>
+				{/if}
+			</div>
+		</Card.Content>
+	</Card.Root>
+</div>

--- a/front/src/routes/(app)/admin/verification/+page.ts
+++ b/front/src/routes/(app)/admin/verification/+page.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Start Codex SAS. All rights reserved.
+// SPDX-License-Identifier: BUSL-1.1
+
+import { redirect } from '@sveltejs/kit';
+import { instance } from '$lib/api';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ parent }) => {
+	const { user } = await parent();
+	if (!user?.is_instance_admin) redirect(302, '/');
+
+	let required = false;
+	try {
+		const config = await instance.verification.get();
+		required = config.required;
+	} catch {
+		// default false
+	}
+
+	return { verificationRequired: required };
+};

--- a/front/src/routes/verify-email/+page.svelte
+++ b/front/src/routes/verify-email/+page.svelte
@@ -1,0 +1,48 @@
+<!-- Copyright (c) 2025 Start Codex SAS. All rights reserved. -->
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+
+<script lang="ts">
+	import type { PageData } from './$types';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as m from '$lib/paraglide/messages';
+	import { i18n } from '$lib/i18n.svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	const t = $derived.by(() => {
+		i18n.locale;
+		return {
+			success: m.verify_success(),
+			invalid: m.verify_invalid(),
+			error: m.verify_error()
+		};
+	});
+</script>
+
+<div class="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+	<div class="flex w-full max-w-sm flex-col gap-6">
+		<a href="/" class="flex items-center gap-2 self-center font-medium">
+			<div class="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">
+				<svg xmlns="http://www.w3.org/2000/svg" class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<rect width="8" height="8" x="2" y="2" rx="2" /><rect width="8" height="8" x="14" y="2" rx="2" />
+					<rect width="8" height="8" x="2" y="14" rx="2" /><rect width="8" height="8" x="14" y="14" rx="2" />
+				</svg>
+			</div>
+			Tookly
+		</a>
+		<Card.Root>
+			<Card.Content class="py-8 text-center">
+				{#if data.status === 'success'}
+					<p class="text-sm text-green-700">{t.success}</p>
+					<a href="/" class="mt-4 inline-block text-sm text-primary underline-offset-4 hover:underline">
+						Continue to Tookly
+					</a>
+				{:else if data.status === 'invalid'}
+					<p class="text-sm text-destructive">{t.invalid}</p>
+				{:else}
+					<p class="text-sm text-destructive">{t.error}</p>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+	</div>
+</div>

--- a/front/src/routes/verify-email/+page.ts
+++ b/front/src/routes/verify-email/+page.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Start Codex SAS. All rights reserved.
+// SPDX-License-Identifier: BUSL-1.1
+
+import { redirect } from '@sveltejs/kit';
+import { instance, auth, ApiError } from '$lib/api';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ url }) => {
+	const { initialized } = await instance.status();
+	if (!initialized) redirect(302, '/setup');
+
+	const token = url.searchParams.get('token') ?? '';
+	if (!token) return { status: 'invalid' as const };
+
+	try {
+		await auth.verifyEmail({ token });
+		return { status: 'success' as const };
+	} catch (err) {
+		if (err instanceof ApiError && err.status === 400) {
+			return { status: 'invalid' as const };
+		}
+		return { status: 'error' as const };
+	}
+};

--- a/internal/emailverification/emailverification.go
+++ b/internal/emailverification/emailverification.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 Start Codex SAS. All rights reserved.
+// SPDX-License-Identifier: BUSL-1.1
+// Use of this software is governed by the Business Source License 1.1
+// included in the LICENSE file at the root of this repository.
+
+package emailverification
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/start-codex/tookly/internal/email"
+	"github.com/start-codex/tookly/internal/instance"
+	"github.com/start-codex/tookly/internal/sessions"
+)
+
+const TokenTTL = 24 * time.Hour
+
+var (
+	ErrTokenNotFound = errors.New("verification token not found")
+	ErrTokenExpired  = errors.New("verification token expired")
+	ErrTokenUsed     = errors.New("verification token already used")
+)
+
+func CreateToken(ctx context.Context, db *sqlx.DB, userID string) (string, error) {
+	if db == nil {
+		return "", errors.New("db is required")
+	}
+	if userID == "" {
+		return "", errors.New("userID is required")
+	}
+	rawToken, err := sessions.GenerateToken()
+	if err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	tokenHash := sessions.HashToken(rawToken)
+	expiresAt := time.Now().Add(TokenTTL)
+	if err := createToken(ctx, db, userID, tokenHash, expiresAt); err != nil {
+		return "", err
+	}
+	return rawToken, nil
+}
+
+func VerifyEmail(ctx context.Context, db *sqlx.DB, rawToken string) error {
+	if db == nil {
+		return errors.New("db is required")
+	}
+	if rawToken == "" {
+		return errors.New("token is required")
+	}
+	tokenHash := sessions.HashToken(rawToken)
+	token, err := getTokenByHash(ctx, db, tokenHash)
+	if err != nil {
+		return err
+	}
+	if token.UsedAt != nil {
+		return ErrTokenUsed
+	}
+	if time.Now().After(token.ExpiresAt) {
+		return ErrTokenExpired
+	}
+
+	// Set email_verified_at on user
+	if err := setEmailVerified(ctx, db, token.UserID); err != nil {
+		return fmt.Errorf("set verified: %w", err)
+	}
+	// Mark token as used
+	return markTokenUsed(ctx, db, tokenHash)
+}
+
+func IsVerificationRequired(ctx context.Context, db *sqlx.DB) (bool, error) {
+	val, err := instance.GetConfig(ctx, db, "email_verification_required")
+	if err != nil {
+		if errors.Is(err, instance.ErrConfigNotFound) {
+			return false, nil // missing key → false
+		}
+		return false, err
+	}
+	if val != "true" && val != "false" {
+		return false, fmt.Errorf("invalid email_verification_required value: %q", val)
+	}
+	return val == "true", nil
+}
+
+// SendVerificationEmail creates a token and sends the verification email.
+func SendVerificationEmail(ctx context.Context, db *sqlx.DB, userID, recipientEmail, baseURL string) error {
+	rawToken, err := CreateToken(ctx, db, userID)
+	if err != nil {
+		return fmt.Errorf("create verification token: %w", err)
+	}
+
+	verifyURL := fmt.Sprintf("%s/verify-email?token=%s", baseURL, rawToken)
+
+	body, err := email.RenderTemplate("email_verification", struct{ VerifyURL string }{verifyURL})
+	if err != nil {
+		return fmt.Errorf("render verification email: %w", err)
+	}
+
+	smtpConfig, _ := instance.LoadSMTPConfig(ctx, db)
+	if err := email.Send(smtpConfig, email.Message{
+		To:      recipientEmail,
+		Subject: "Verify your Tookly email",
+		Body:    body,
+	}); err != nil {
+		return fmt.Errorf("send verification email: %w", err)
+	}
+	return nil
+}

--- a/internal/emailverification/handler.go
+++ b/internal/emailverification/handler.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2025 Start Codex SAS. All rights reserved.
+// SPDX-License-Identifier: BUSL-1.1
+// Use of this software is governed by the Business Source License 1.1
+// included in the LICENSE file at the root of this repository.
+
+package emailverification
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/instance"
+	"github.com/start-codex/tookly/internal/respond"
+	"github.com/start-codex/tookly/internal/users"
+)
+
+func RegisterRoutes(mux *http.ServeMux, db *sqlx.DB) {
+	mux.HandleFunc("POST /auth/verify-email", handleVerifyEmail(db))
+	mux.HandleFunc("POST /auth/resend-verification", handleResendVerification(db))
+	mux.HandleFunc("GET /instance/verification", handleGetVerificationConfig(db))
+	mux.HandleFunc("POST /instance/verification", handleSetVerificationConfig(db))
+}
+
+func handleVerifyEmail(db *sqlx.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Token string `json:"token"`
+		}
+		if err := respond.Decode(r, &body); err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		if body.Token == "" {
+			respond.Error(w, http.StatusBadRequest, "token is required")
+			return
+		}
+		if err := VerifyEmail(r.Context(), db, body.Token); err != nil {
+			if errors.Is(err, ErrTokenNotFound) || errors.Is(err, ErrTokenExpired) || errors.Is(err, ErrTokenUsed) {
+				respond.Error(w, http.StatusBadRequest, "invalid_or_expired_token")
+				return
+			}
+			respond.Error(w, http.StatusInternalServerError, "internal server error")
+			return
+		}
+		respond.JSON(w, http.StatusOK, map[string]string{"status": "verified"})
+	}
+}
+
+func handleResendVerification(db *sqlx.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, err := authz.UserIDFromContext(r.Context())
+		if err != nil {
+			respond.Error(w, http.StatusUnauthorized, "authentication required")
+			return
+		}
+		user, err := users.GetUser(r.Context(), db, userID)
+		if err != nil {
+			respond.Error(w, http.StatusInternalServerError, "internal server error")
+			return
+		}
+		// Idempotent: already verified → success without sending
+		if user.EmailVerifiedAt != nil {
+			respond.JSON(w, http.StatusOK, map[string]string{"status": "already_verified"})
+			return
+		}
+		// Build base URL
+		baseURL, _ := instance.GetConfig(r.Context(), db, "base_url")
+		if baseURL == "" {
+			baseURL = r.Header.Get("Origin")
+		}
+		if baseURL == "" {
+			proto := r.Header.Get("X-Forwarded-Proto")
+			if proto == "" {
+				proto = "http"
+			}
+			baseURL = fmt.Sprintf("%s://%s", proto, r.Host)
+		}
+		if err := SendVerificationEmail(r.Context(), db, userID, user.Email, baseURL); err != nil {
+			respond.Error(w, http.StatusInternalServerError, "failed to send verification email")
+			return
+		}
+		respond.JSON(w, http.StatusOK, map[string]string{"status": "sent"})
+	}
+}
+
+func handleGetVerificationConfig(db *sqlx.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := authz.RequireInstanceAdmin(r.Context(), db); err != nil {
+			respond.Error(w, http.StatusForbidden, "forbidden")
+			return
+		}
+		required, err := IsVerificationRequired(r.Context(), db)
+		if err != nil {
+			respond.Error(w, http.StatusInternalServerError, "internal server error")
+			return
+		}
+		respond.JSON(w, http.StatusOK, map[string]bool{"required": required})
+	}
+}
+
+func handleSetVerificationConfig(db *sqlx.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := authz.RequireInstanceAdmin(r.Context(), db); err != nil {
+			respond.Error(w, http.StatusForbidden, "forbidden")
+			return
+		}
+		var body struct {
+			Required bool `json:"required"`
+		}
+		if err := respond.Decode(r, &body); err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		val := "false"
+		if body.Required {
+			val = "true"
+		}
+		if err := instance.SetConfig(r.Context(), db, "email_verification_required", val); err != nil {
+			respond.Error(w, http.StatusInternalServerError, "internal server error")
+			return
+		}
+		respond.JSON(w, http.StatusOK, map[string]string{"status": "saved"})
+	}
+}

--- a/internal/emailverification/store.go
+++ b/internal/emailverification/store.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Start Codex SAS. All rights reserved.
+// SPDX-License-Identifier: BUSL-1.1
+// Use of this software is governed by the Business Source License 1.1
+// included in the LICENSE file at the root of this repository.
+
+package emailverification
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type verificationToken struct {
+	ID        string     `db:"id"`
+	UserID    string     `db:"user_id"`
+	TokenHash string     `db:"token_hash"`
+	ExpiresAt time.Time  `db:"expires_at"`
+	UsedAt    *time.Time `db:"used_at"`
+	CreatedAt time.Time  `db:"created_at"`
+}
+
+func createToken(ctx context.Context, db *sqlx.DB, userID, tokenHash string, expiresAt time.Time) error {
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO email_verification_tokens (user_id, token_hash, expires_at)
+		 VALUES ($1, $2, $3)`,
+		userID, tokenHash, expiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert verification token: %w", err)
+	}
+	return nil
+}
+
+func getTokenByHash(ctx context.Context, db *sqlx.DB, tokenHash string) (verificationToken, error) {
+	var token verificationToken
+	err := db.GetContext(ctx, &token,
+		`SELECT id, user_id, token_hash, expires_at, used_at, created_at
+		 FROM email_verification_tokens WHERE token_hash = $1`,
+		tokenHash,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return verificationToken{}, ErrTokenNotFound
+		}
+		return verificationToken{}, fmt.Errorf("get verification token: %w", err)
+	}
+	return token, nil
+}
+
+func markTokenUsed(ctx context.Context, db *sqlx.DB, tokenHash string) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE email_verification_tokens SET used_at = NOW() WHERE token_hash = $1`,
+		tokenHash,
+	)
+	if err != nil {
+		return fmt.Errorf("mark verification token used: %w", err)
+	}
+	return nil
+}
+
+func setEmailVerified(ctx context.Context, db *sqlx.DB, userID string) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE app_users SET email_verified_at = NOW(), updated_at = NOW() WHERE id = $1 AND email_verified_at IS NULL`,
+		userID,
+	)
+	if err != nil {
+		return fmt.Errorf("set email verified: %w", err)
+	}
+	return nil
+}

--- a/internal/invitations/handler.go
+++ b/internal/invitations/handler.go
@@ -206,6 +206,13 @@ func handleAccept(db *sqlx.DB) http.HandlerFunc {
 			return
 		}
 
+		// Look up invitation before accept (token becomes unusable after)
+		inv, invErr := GetInvitation(r.Context(), db, body.Token)
+		if invErr != nil {
+			fail(w, invErr)
+			return
+		}
+
 		var userID string
 
 		// Check if authenticated (existing user accepting)
@@ -214,11 +221,6 @@ func handleAccept(db *sqlx.DB) http.HandlerFunc {
 			userID = authedUserID
 		} else if body.Email != "" && body.Name != "" && body.Password != "" {
 			// New user registration via invitation — verify email matches
-			inv, invErr := GetInvitation(r.Context(), db, body.Token)
-			if invErr != nil {
-				fail(w, invErr)
-				return
-			}
 			if body.Email != inv.Email {
 				respond.Error(w, http.StatusBadRequest, "email must match the invitation")
 				return
@@ -233,6 +235,9 @@ func handleAccept(db *sqlx.DB) http.HandlerFunc {
 				return
 			}
 			userID = newUser.ID
+
+			// Send verification email if required
+			users.TrySendVerificationEmail(r, db, newUser.ID, newUser.Email)
 		} else {
 			respond.Error(w, http.StatusBadRequest, "must be authenticated or provide email, name, and password")
 			return
@@ -243,8 +248,6 @@ func handleAccept(db *sqlx.DB) http.HandlerFunc {
 			return
 		}
 
-		// Get workspace slug for redirect
-		inv, _ := GetInvitation(r.Context(), db, body.Token)
 		ws, _ := workspaces.GetWorkspace(r.Context(), db, inv.WorkspaceID)
 
 		respond.JSON(w, http.StatusOK, map[string]string{

--- a/internal/users/handler.go
+++ b/internal/users/handler.go
@@ -7,11 +7,14 @@ package users
 
 import (
 	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/start-codex/tookly/internal/authz"
+	"github.com/start-codex/tookly/internal/email"
 	"github.com/start-codex/tookly/internal/respond"
 	"github.com/start-codex/tookly/internal/sessions"
 )
@@ -82,6 +85,10 @@ func handleCreate(db *sqlx.DB) http.HandlerFunc {
 			fail(w, err)
 			return
 		}
+
+		// Send verification email if required (inline to avoid import cycle)
+		TrySendVerificationEmail(r, db, user.ID, user.Email)
+
 		respond.JSON(w, http.StatusCreated, user)
 	}
 }
@@ -142,7 +149,18 @@ func handleMe(db *sqlx.DB) http.HandlerFunc {
 			respond.Error(w, http.StatusInternalServerError, "internal server error")
 			return
 		}
-		respond.JSON(w, http.StatusOK, map[string]any{"authenticated": true, "user": user})
+		// Check if email verification is required (inline to avoid import cycle with instance)
+		verificationRequired := false
+		var reqVal string
+		if err := db.GetContext(r.Context(), &reqVal,
+			`SELECT value FROM instance_config WHERE key = 'email_verification_required'`); err == nil {
+			verificationRequired = reqVal == "true"
+		}
+		respond.JSON(w, http.StatusOK, map[string]any{
+			"authenticated":               true,
+			"user":                         user,
+			"email_verification_required":  verificationRequired,
+		})
 	}
 }
 
@@ -211,4 +229,66 @@ func handleGet(db *sqlx.DB) http.HandlerFunc {
 		}
 		respond.JSON(w, http.StatusOK, user)
 	}
+}
+
+// TrySendVerificationEmail checks if email verification is required and sends
+// the verification email. Errors are logged but never fail the caller.
+func TrySendVerificationEmail(r *http.Request, db *sqlx.DB, userID, userEmail string) {
+	ctx := r.Context()
+	var reqVal string
+	if err := db.GetContext(ctx, &reqVal,
+		`SELECT value FROM instance_config WHERE key = 'email_verification_required'`); err != nil {
+		return
+	}
+	if reqVal != "true" {
+		return
+	}
+
+	rawToken, err := sessions.GenerateToken()
+	if err != nil {
+		slog.Error("verification token generation failed", "error", err)
+		return
+	}
+	tokenHash := sessions.HashToken(rawToken)
+	if _, err = db.ExecContext(ctx,
+		`INSERT INTO email_verification_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, NOW() + INTERVAL '24 hours')`,
+		userID, tokenHash); err != nil {
+		slog.Error("verification token insert failed", "error", err)
+		return
+	}
+
+	baseURL := ""
+	_ = db.GetContext(ctx, &baseURL, `SELECT value FROM instance_config WHERE key = 'base_url'`)
+	if baseURL == "" {
+		baseURL = r.Header.Get("Origin")
+	}
+	if baseURL == "" {
+		proto := r.Header.Get("X-Forwarded-Proto")
+		if proto == "" {
+			proto = "http"
+		}
+		baseURL = fmt.Sprintf("%s://%s", proto, r.Host)
+	}
+
+	body, err := email.RenderTemplate("email_verification", struct{ VerifyURL string }{
+		fmt.Sprintf("%s/verify-email?token=%s", baseURL, rawToken),
+	})
+	if err != nil {
+		slog.Error("verification email render failed", "error", err)
+		return
+	}
+
+	var smtpHost, smtpPortStr, smtpFrom, smtpUser, smtpPass string
+	_ = db.GetContext(ctx, &smtpHost, `SELECT value FROM instance_config WHERE key = 'smtp_host'`)
+	_ = db.GetContext(ctx, &smtpPortStr, `SELECT value FROM instance_config WHERE key = 'smtp_port'`)
+	_ = db.GetContext(ctx, &smtpFrom, `SELECT value FROM instance_config WHERE key = 'smtp_from'`)
+	_ = db.GetContext(ctx, &smtpUser, `SELECT value FROM instance_config WHERE key = 'smtp_username'`)
+	_ = db.GetContext(ctx, &smtpPass, `SELECT value FROM instance_config WHERE key = 'smtp_password'`)
+	if smtpHost == "" {
+		return
+	}
+	port := 587
+	fmt.Sscanf(smtpPortStr, "%d", &port)
+	_ = email.Send(&email.SMTPConfig{Host: smtpHost, Port: port, From: smtpFrom, Username: smtpUser, Password: smtpPass},
+		email.Message{To: userEmail, Subject: "Verify your Tookly email", Body: body})
 }

--- a/internal/users/store.go
+++ b/internal/users/store.go
@@ -15,7 +15,7 @@ import (
 	"github.com/start-codex/tookly/internal/pgutil"
 )
 
-const userCols = `id, email, name, is_instance_admin, created_at, updated_at, archived_at`
+const userCols = `id, email, name, is_instance_admin, email_verified_at, created_at, updated_at, archived_at`
 
 func createUser(ctx context.Context, db *sqlx.DB, params CreateUserParams) (User, error) {
 	hash, err := hashPassword(params.Password)
@@ -45,8 +45,8 @@ func createInstanceAdminTx(ctx context.Context, tx *sqlx.Tx, params CreateUserPa
 	}
 	var user User
 	err = tx.QueryRowxContext(ctx,
-		`INSERT INTO app_users (email, name, password_hash, is_instance_admin)
-		 VALUES ($1, $2, $3, true)
+		`INSERT INTO app_users (email, name, password_hash, is_instance_admin, email_verified_at)
+		 VALUES ($1, $2, $3, true, NOW())
 		 RETURNING `+userCols,
 		params.Email, params.Name, hash,
 	).StructScan(&user)

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -25,14 +25,15 @@ var (
 )
 
 type User struct {
-	ID              string     `db:"id"               json:"id"`
-	Email           string     `db:"email"            json:"email"`
-	Name            string     `db:"name"             json:"name"`
+	ID              string     `db:"id"                json:"id"`
+	Email           string     `db:"email"             json:"email"`
+	Name            string     `db:"name"              json:"name"`
 	IsInstanceAdmin bool       `db:"is_instance_admin" json:"is_instance_admin"`
-	CreatedAt       time.Time  `db:"created_at"       json:"created_at"`
-	UpdatedAt       time.Time  `db:"updated_at"       json:"updated_at"`
-	ArchivedAt      *time.Time `db:"archived_at"      json:"archived_at,omitempty"`
-	PasswordHash    string     `db:"password_hash"    json:"-"`
+	EmailVerifiedAt *time.Time `db:"email_verified_at" json:"email_verified_at,omitempty"`
+	CreatedAt       time.Time  `db:"created_at"        json:"created_at"`
+	UpdatedAt       time.Time  `db:"updated_at"        json:"updated_at"`
+	ArchivedAt      *time.Time `db:"archived_at"       json:"archived_at,omitempty"`
+	PasswordHash    string     `db:"password_hash"     json:"-"`
 }
 
 type CreateUserParams struct {

--- a/migrations/0008_add_email_verified_to_users.down.sql
+++ b/migrations/0008_add_email_verified_to_users.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_users DROP COLUMN IF EXISTS email_verified_at;

--- a/migrations/0008_add_email_verified_to_users.up.sql
+++ b/migrations/0008_add_email_verified_to_users.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_users ADD COLUMN email_verified_at TIMESTAMPTZ;

--- a/migrations/0009_create_email_verification_tokens.down.sql
+++ b/migrations/0009_create_email_verification_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS email_verification_tokens;

--- a/migrations/0009_create_email_verification_tokens.up.sql
+++ b/migrations/0009_create_email_verification_tokens.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE email_verification_tokens (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID        NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+    token_hash TEXT        NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_email_verification_tokens_user ON email_verification_tokens(user_id);
+CREATE INDEX idx_email_verification_tokens_hash ON email_verification_tokens(token_hash);


### PR DESCRIPTION
Closes #35

## Summary
- Add optional email verification: admin toggle at `/admin/verification`, verification banner with resend button, `/verify-email` page, and `POST /auth/verify-email` + `POST /auth/resend-verification` endpoints
- Token-based flow (SHA-256, 24h TTL) with migrations `0008` and `0009`; bootstrap admin is pre-verified (`email_verified_at = NOW()`)
- Verification email sent on user creation (`POST /users`) and invitation-based registration (`POST /invitations/accept`)
- `GET /auth/me` includes `email_verification_required` for frontend soft enforcement (banner, no blocking)
- Fix: invitation accept now captures workspace info before marking token as accepted, preventing empty `workspace_slug` in response
- i18n: English and Spanish translations for all verification strings

## Test plan
- [x] Enable verification toggle → create user → verify email arrives in Mailpit
- [x] Verification banner visible for unverified users, hidden after verify
- [x] Resend button sends new email; resend for already-verified user returns `already_verified`
- [x] Invalid/expired token shows error on verify-email page
- [x] Bootstrap admin has no banner (pre-verified)
- [x] Disable toggle → no banner, no verification emails
- [x] Invitation accept returns correct `workspace_slug` after acceptance
- [x] `go test -count=1 ./internal/... ./cmd/server/...` passes
- [x] `cd front && pnpm build` passes